### PR TITLE
59 Input: Label overlaps the input field when the element is invalid

### DIFF
--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -190,7 +190,9 @@ export class LeuInput extends LitElement {
    * @returns {void}
    */
   handleChange(event) {
-    this.value = event.target.value
+    if (event.target.validity.valid) {
+      this.value = event.target.value
+    }
 
     const customEvent = new CustomEvent(event.type, event)
     this.dispatchEvent(customEvent)
@@ -205,7 +207,9 @@ export class LeuInput extends LitElement {
    * @returns {void}
    */
   handleInput(event) {
-    this.value = event.target.value
+    if (event.target.validity.valid) {
+      this.value = event.target.value
+    }
 
     const customEvent = new CustomEvent("input", {
       bubbles: true,

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,6 +1,7 @@
 import { html, LitElement, nothing } from "lit"
 import { classMap } from "lit/directives/class-map.js"
 import { ifDefined } from "lit/directives/if-defined.js"
+import { live } from "lit/directives/live.js"
 import { createRef, ref } from "lit/directives/ref.js"
 
 import { Icon } from "../icon/icon.js"
@@ -207,9 +208,7 @@ export class LeuInput extends LitElement {
    * @returns {void}
    */
   handleInput(event) {
-    if (event.target.validity.valid) {
-      this.value = event.target.value
-    }
+    this.value = event.target.value
 
     const customEvent = new CustomEvent("input", {
       bubbles: true,
@@ -402,12 +401,12 @@ export class LeuInput extends LitElement {
           @invalid=${this.handleInvalid}
           ?disabled=${this.disabled}
           ?required=${this.required}
+          .value=${live(this.value)}
           pattern=${ifDefined(this.pattern)}
           min=${ifDefined(this.min)}
           max=${ifDefined(this.max)}
           maxlength=${ifDefined(this.maxlength)}
           minlength=${ifDefined(this.minlength)}
-          .value=${this.value ?? ""}
           ref=${ref(this._inputRef)}
           aria-invalid=${isInvalid}
         />

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -116,7 +116,8 @@
 
 /* is size regular AND (has focus OR contains a value) */
 :host(:not([size])) .label,
-:host([size="regular"]) .label {
+:host([size="regular"]) .label,
+.input-wrapper--invalid .label {
   top: calc(0.75rem - var(--input-border-width));
 
   font-size: 0.75rem;

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -115,9 +115,9 @@
 }
 
 /* is size regular AND (has focus OR contains a value) */
+.input-wrapper--invalid .label,
 :host(:not([size])) .label,
-:host([size="regular"]) .label,
-.input-wrapper--invalid .label {
+:host([size="regular"]) .label {
   top: calc(0.75rem - var(--input-border-width));
 
   font-size: 0.75rem;
@@ -139,16 +139,18 @@
   content: "*";
 }
 
-/* is empty AND has no focus */
-:host(:not(:focus-within)) .input-wrapper--empty .label {
-  font-family: var(--input-font-regular);
-  font-size: 1rem;
-  top: calc(1.5rem - var(--input-border-width));
-}
-
 /* is not disabled AND has focus AND is empty */
 :host(:not([disabled], :focus-within)) .input-wrapper--empty .label {
   --input-label-color: var(--input-label-color-empty);
+}
+
+/* is empty AND has no focus */
+:host(:not(:focus-within))
+  .input-wrapper--empty:not(.input-wrapper--invalid)
+  .label {
+  font-family: var(--input-font-regular);
+  font-size: 1rem;
+  top: calc(1.5rem - var(--input-border-width));
 }
 
 /* is size small AND has no focus AND is empty */

--- a/src/components/input/stories/input.stories.js
+++ b/src/components/input/stories/input.stories.js
@@ -15,7 +15,7 @@ export default {
       control: {
         type: "select",
       },
-      options: SIZE_TYPES,
+      options: Object.values(SIZE_TYPES),
     },
     icon: { control: "select", options: ICON_NAMES },
   },


### PR DESCRIPTION
The native input element with type "number" has always a value of an empty string when it is invalid. No matter what the user has typed in the input field and what is visible to them.

The input component can't differentiate between a native input element that is actually empty and a native input element that has a "visible" value but is invalid (and therefore `this.value === ""`). That's why until now the component displayed the label like it was empty even though an input text was visible to the user.

The browsers also have different implementations. Firefox allows letters to be typed into an input element with `type="number` whereas Chrome doesn't allow that.

When the input element is invalid the label will now always be displayed like it has a value (small at the top).
Sadly this means that if the input is required and empty and therefore invalid, the label is also positioned like there is a value. But i rather live with this behaviour at the moment than having an overlapping text element or having to implement a workaround.

Using the [`live` directive](https://lit.dev/docs/templates/directives/#live) also helps to prevent a buggy behaviour that reset the value of the input when the input turned invalid while typing.