### PR TITLE
Breadcrumb Refactoring

### DIFF
--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing } from "lit"
 import { createRef, ref } from "lit/directives/ref.js"
+import { classMap } from "lit/directives/class-map.js"
 
 import styles from "./breadcrumb.css"
 import { Icon } from "../icon/icon.js"
@@ -253,17 +254,22 @@ export class LeuBreadcrumb extends LitElement {
     const showBackOnly =
       this._showBackOnly || this.items.length - this._hiddenItems < 2
 
+    const wrapperClasses = {
+      breadcrumbs: true,
+      "breadcrumbs--back-only": showBackOnly,
+    }
+
     return html`
-      <nav class="breadcrumbs">
+      <nav class=${classMap(wrapperClasses)}>
         <h2 class="visuallyhidden">Sie sind hier:</h2>
         <ol class="breadcrumbs__list" ref=${ref(this._containerRef)}>
           ${showBackOnly
-            ? html`<span class="breadrumbs__icon">${Icon("arrowLeft")}</span>
-                <li class="breadcrumbs__item">
-                  <a class="breadcrumbs__link" href=${parentItem.href}
-                    >${parentItem.label}</a
-                  >
-                </li>`
+            ? html` <li class="breadcrumbs__item breadcrumbs__item--back">
+                <span class="breadcrumbs__icon">${Icon("arrowLeft")}</span>
+                <a class="breadcrumbs__link" href=${parentItem.href}
+                  >${parentItem.label}</a
+                >
+              </li>`
             : this._listItems.map(
                 (item, index, list) =>
                   html`

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -217,8 +217,8 @@ export class LeuBreadcrumb extends LitElement {
       return nothing
 
     return html`
-      <li data-dropdown-toggle>
-        <span>${Icon("angleRight")}</span>
+      <li class="breadcrumbs__item" data-dropdown-toggle>
+        <span class="breadcrumbs__icon">${Icon("angleRight")}</span>
         <div class="dropdown">
           <button class="menu" @click=${this._openDropdown} tabindex="0">
             &hellip;
@@ -254,23 +254,30 @@ export class LeuBreadcrumb extends LitElement {
       this._showBackOnly || this.items.length - this._hiddenItems < 2
 
     return html`
-      <nav class="fontsize">
+      <nav class="breadcrumbs">
         <h2 class="visuallyhidden">Sie sind hier:</h2>
-        <ol ref=${ref(this._containerRef)}>
+        <ol class="breadcrumbs__list" ref=${ref(this._containerRef)}>
           ${showBackOnly
-            ? html`${Icon("arrowLeft")}<a href=${parentItem.href}
-                  >${parentItem.label}</a
-                >`
+            ? html`<span class="breadrumbs__icon">${Icon("arrowLeft")}</span>
+                <li class="breadcrumbs__item">
+                  <a class="breadcrumbs__link" href=${parentItem.href}
+                    >${parentItem.label}</a
+                  >
+                </li>`
             : this._listItems.map(
                 (item, index, list) =>
                   html`
-                    <li>
+                    <li class="breadcrumbs__item">
                       ${index > 0
-                        ? html`<span>${Icon("angleRight")}</span>` // First list item doesn't have an arrow
+                        ? html`<span class="breadcrumbs__icon"
+                            >${Icon("angleRight")}</span
+                          >` // First list item doesn't have an arrow
                         : nothing}
                       ${index === list.length - 1
                         ? item.label // Last list item doesn't contain a link
-                        : html`<a href=${item.href}>${item.label}</a>`}
+                        : html`<a class="breadcrumbs__link" href=${item.href}
+                            >${item.label}</a
+                          >`}
                     </li>
                     ${index === 0 ? this.renderDropdown() : nothing}
                   `

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -55,7 +55,7 @@ export class LeuBreadcrumb extends LitElement {
     _isDropdownOpen: { state: true },
   }
 
-  static BACK_ONLY_BREAKPOINT = 100
+  static BACK_ONLY_BREAKPOINT = 320
 
   constructor() {
     super()
@@ -134,6 +134,8 @@ export class LeuBreadcrumb extends LitElement {
       this._isRecalculating = false
       return
     }
+
+    this._showBackOnly = false
 
     /**
      *  In order to calculate how many items can be displayed

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -5,10 +5,36 @@ import styles from "./breadcrumb.css"
 import { Icon } from "../icon/icon.js"
 import "../menu/leu-menu.js"
 import "../menu/leu-menu-item.js"
-// import { debounce } from "../../lib/utils.js"
+import { debounce } from "../../lib/utils.js"
 
 /**
  * A Breadcrumb Navigation.
+ *
+ * The breadcrumbs can be displayed in two different layouts.
+ * Only the back link (the last item / parent of the current page)
+ * is displayed when…
+ * -  … the width of the container is smaller
+ *      than the BACK_ONLY_BREAKPOINT.
+ * -  … less then two breadcrumb items could be displayed
+ *      without overflowing the container.
+ *
+ * Otherwise as many items as possible are displayed in an inline list
+ * without overflowing the container. The remaining items are displayed
+ * in a dropdown menu.
+ *
+ * In order to determine the exact numbers of items that have to be
+ * hidden inside the dropdown, all of them have to be rendered first.
+ * 1. Render all items
+ * 2. Calculate (measure) the number of items that can be displayed
+ *    without overflowing the container.
+ * 3. Updating the state (_hiddeItems) which will trigger a rerender
+ * 4. Render the items again with the new state.
+ *
+ * This results in multiple updates scheduled one after another. Lit
+ * will also print a waring in the console beacause of that.
+ * It's no a nice behaviour but the only one that works without
+ * having duplicate and hidden markup to derive the sizes from that.
+ *
  *
  * @prop {Array} items - Object array with { label, href }
  * @prop {Boolean} inverted - invert color on dark background
@@ -24,15 +50,17 @@ export class LeuBreadcrumb extends LitElement {
 
     _hiddenItems: { state: true },
     _showBackOnly: { state: true },
+    _isRecalculating: { state: true },
+    _isDropdownOpen: { state: true },
   }
 
   static BACK_ONLY_BREAKPOINT = 100
 
   constructor() {
     super()
-    /** @type {array} */
+    /** @type {Array} */
     this.items = []
-    /** @type {boolean} - will be used on dark Background */
+    /** @type {Boolean} - will be used on dark Background */
     this.inverted = false
 
     /** @internal */
@@ -45,25 +73,31 @@ export class LeuBreadcrumb extends LitElement {
     this._showBackOnly = null
     /** @internal */
     this._lastContainerWidth = null
+    /**
+     * @internal
+     * Forces the toggle button to be rendered
+     * so that all possible inline items will be measured.
+     * */
+    this._isRecalculating = true
+    /** @internal */
+    this._isDropdownOpen = false
 
-    this.resizeObserver = new ResizeObserver(() => {
-      this._checkWidth()
-    })
+    this.resizeObserver = new ResizeObserver(
+      debounce(() => {
+        this._handleResize()
+      }, 500)
+    )
   }
 
   firstUpdated() {
     this.resizeObserver.observe(this._containerRef.value)
   }
 
-  updated(changedProperties) {
+  async updated(changedProperties) {
     if (changedProperties.has("items")) {
-      this._checkWidth()
-    }
-
-    if (
-      changedProperties.has("_hiddenItems") &&
-      changedProperties.get("_hiddenItems") > this._hiddenItems
-    ) {
+      this._hiddenItems = 0
+      this._isRecalculating = true
+      await this.updateComplete
       this._checkWidth()
     }
   }
@@ -71,14 +105,7 @@ export class LeuBreadcrumb extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback()
 
-    if (
-      this._dropdownRef &&
-      this._dropdownRef.value &&
-      this._dropdownRef.value.classList.contains("show")
-    ) {
-      this._closeDropdown()
-    }
-
+    window.removeEventListener("click", this._closeDropdown)
     this.resizeObserver.disconnect()
   }
 
@@ -92,34 +119,66 @@ export class LeuBreadcrumb extends LitElement {
     return this.items.slice(1, 1 + this._hiddenItems)
   }
 
+  _handleResize = async () => {
+    const containerOffsetWidth = this._containerRef.value.offsetWidth
+    const sizeIsGrowing = containerOffsetWidth > this._lastContainerWidth
+    this._lastContainerWidth = containerOffsetWidth
+
+    /**
+     * Show only the back link (parent of the current page)
+     * when the width of the container is smaller than the BACK_ONLY_BREAKPOINT
+     */
+    if (containerOffsetWidth <= LeuBreadcrumb.BACK_ONLY_BREAKPOINT) {
+      this._showBackOnly = true
+      this._isRecalculating = false
+      return
+    }
+
+    /**
+     *  In order to calculate how many items can be displayed
+     *  when the container is growing, all items have to
+     *  be marked as displayed (_hiddenItems = 0) and
+     *  rendered.
+     */
+    if (sizeIsGrowing && this._hiddenItems > 0) {
+      this._hiddenItems = 0
+      this._isRecalculating = true
+      await this.updateComplete
+    }
+
+    this._checkWidth()
+  }
+
+  /**
+   * Calculate the number of items that can be displayed
+   * without overflowing the container.
+   * @internal
+   * @returns {void}
+   */
   _checkWidth() {
     const containerOffsetWidth = this._containerRef.value.offsetWidth
     const containerScrollWidth = this._containerRef.value.scrollWidth
-
-    const sizeIsGrowing = containerOffsetWidth > this._lastContainerWidth
-
     this._lastContainerWidth = containerOffsetWidth
 
-    if (containerOffsetWidth <= LeuBreadcrumb.BACK_ONLY_BREAKPOINT) {
-      this._showBackOnly = true
+    /** When the container is not overflowing, nothing has to be done */
+    if (containerOffsetWidth === containerScrollWidth) {
+      this._isRecalculating = false
       return
     }
 
-    this._showBackOnly = false
-
-    if (sizeIsGrowing) {
-      this._hiddenItems = 0
-      return
-    }
-
-    if (containerOffsetWidth === containerScrollWidth) return
-
-    const listItems = this._containerRef.value.querySelectorAll("li")
+    const listItems = this._containerRef.value.querySelectorAll(
+      "li:not([data-dropdown-toggle])"
+    )
     const listItemWidths = [...listItems].map((o) => o.offsetWidth)
 
     let hiddenItems = 0
     let nextItemWidthSum = containerScrollWidth
 
+    /**
+     * Remove item by item until the sum of the remaining items
+     * is smaller than the width of the container.
+     * The first item will not be removed.
+     */
     while (
       hiddenItems < listItemWidths.length &&
       containerOffsetWidth < nextItemWidthSum
@@ -132,25 +191,20 @@ export class LeuBreadcrumb extends LitElement {
     }
 
     this._hiddenItems += hiddenItems
+    this._isRecalculating = false
   }
 
   /** @internal */
   _openDropdown = (e) => {
-    // arrow function to use this in event listener
-    if (e) {
-      e.stopPropagation()
-    }
-    this._dropdownRef.value.classList.add("show")
+    e.stopPropagation()
+    this._isDropdownOpen = true
     window.addEventListener("click", this._closeDropdown)
   }
 
   /** @internal */
   _closeDropdown = (e) => {
-    // arrow function to use this in event listener
-    if (e) {
-      e.stopPropagation()
-    }
-    this._dropdownRef.value.classList.remove("show")
+    e.stopPropagation()
+    this._isDropdownOpen = false
     window.removeEventListener("click", this._closeDropdown)
   }
 
@@ -159,30 +213,33 @@ export class LeuBreadcrumb extends LitElement {
    * @returns
    */
   renderDropdown() {
-    if (this._dropdownItems.length === 0) return nothing
+    if (this._dropdownItems.length === 0 && !this._isRecalculating)
+      return nothing
 
     return html`
-      <li>
+      <li data-dropdown-toggle>
         <span>${Icon("angleRight")}</span>
         <div class="dropdown">
           <button class="menu" @click=${this._openDropdown} tabindex="0">
             &hellip;
           </button>
-          <div ref=${ref(this._dropdownRef)} class="dropdown-content">
-            ${html`
-              <leu-menu>
-                ${this._dropdownItems.map(
-                  (item) =>
-                    html`
-                      <leu-menu-item
-                        label=${item.label}
-                        href=${item.href}
-                      ></leu-menu-item>
-                    `
-                )}
-              </leu-menu>
-            `}
-          </div>
+          ${this._isDropdownOpen
+            ? html`<div ref=${ref(this._dropdownRef)} class="dropdown-content">
+                ${html`
+                  <leu-menu>
+                    ${this._dropdownItems.map(
+                      (item) =>
+                        html`
+                          <leu-menu-item
+                            label=${item.label}
+                            href=${item.href}
+                          ></leu-menu-item>
+                        `
+                    )}
+                  </leu-menu>
+                `}
+              </div>`
+            : nothing}
         </div>
       </li>
     `
@@ -209,10 +266,10 @@ export class LeuBreadcrumb extends LitElement {
                   html`
                     <li>
                       ${index > 0
-                        ? html`<span>${Icon("angleRight")}</span>` // First list item should not have an arrow
+                        ? html`<span>${Icon("angleRight")}</span>` // First list item doesn't have an arrow
                         : nothing}
                       ${index === list.length - 1
-                        ? item.label // Last list item should not be a link
+                        ? item.label // Last list item doesn't contain a link
                         : html`<a href=${item.href}>${item.label}</a>`}
                     </li>
                     ${index === 0 ? this.renderDropdown() : nothing}

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -172,7 +172,7 @@ export class LeuBreadcrumb extends LitElement {
     const listItemWidths = [...listItems].map((o) => o.offsetWidth)
 
     let hiddenItems = 0
-    let nextItemWidthSum = containerScrollWidth
+    let hiddenItemsWidth = 0
 
     /**
      * Remove item by item until the sum of the remaining items
@@ -181,12 +181,12 @@ export class LeuBreadcrumb extends LitElement {
      */
     while (
       hiddenItems < listItemWidths.length &&
-      containerOffsetWidth < nextItemWidthSum
+      containerOffsetWidth < containerScrollWidth - hiddenItemsWidth
     ) {
       hiddenItems += 1
 
-      nextItemWidthSum = listItemWidths
-        .toSpliced(1, hiddenItems)
+      hiddenItemsWidth = listItemWidths
+        .slice(1, 1 + hiddenItems)
         .reduce((sum, itemWidth) => sum + itemWidth, 0)
     }
 

--- a/src/components/breadcrumb/breadcrumb.css
+++ b/src/components/breadcrumb/breadcrumb.css
@@ -22,8 +22,10 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+}
 
-  /* overflow: hidden; */
+.breadcrumbs--back-only .breadcrumbs__list {
+  overflow: hidden;
 }
 
 .breadcrumbs__item,
@@ -34,8 +36,12 @@
   white-space: nowrap;
 }
 
-.breadcrumbs__item:first-child {
+.breadcrumbs__item:first-child:not(.breadcrumbs__item--back) {
   font-family: var(--breadcrumb-font-black);
+}
+
+.breadcrumbs__item--back {
+  max-width: 100%;
 }
 
 .breadcrumbs__link {
@@ -43,6 +49,12 @@
   text-decoration: none;
   transition: color 0.1s ease;
   white-space: nowrap;
+}
+
+.breadcrumbs__item--back .breadcrumbs__link {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 0.25rem;
 }
 
 .menu {

--- a/src/components/breadcrumb/breadcrumb.css
+++ b/src/components/breadcrumb/breadcrumb.css
@@ -9,15 +9,16 @@
 
   font-family: var(--breadcrumb-font-regular);
   line-height: 1.5;
-  color: #000;
+  color: var(--leu-color-black-100);
 }
 
 :host([inverted]) {
-  color: #fff;
+  color: var(--leu-color-black-0);
 }
 
-ol {
+.breadcrumbs__list {
   display: flex;
+  align-items: center;
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -25,23 +26,23 @@ ol {
   /* overflow: hidden; */
 }
 
-li,
-span {
+.breadcrumbs__item,
+.breadcrumbs__icon {
   align-items: center;
   display: flex;
   min-height: 1.875rem;
   white-space: nowrap;
 }
 
-a {
+.breadcrumbs__item:first-child {
+  font-family: var(--breadcrumb-font-black);
+}
+
+.breadcrumbs__link {
   color: inherit;
   text-decoration: none;
   transition: color 0.1s ease;
   white-space: nowrap;
-}
-
-li:first-child {
-  font-family: var(--breadcrumb-font-black);
 }
 
 .menu {
@@ -63,7 +64,7 @@ li:first-child {
 
 .dropdown-content {
   position: absolute;
-  background-color: #fff;
+  background-color: var(--leu-color-black-0);
   min-width: 160px;
   overflow: visible;
   box-shadow: var(--leu-box-shadow-short);
@@ -81,30 +82,30 @@ li:first-child {
   width: 1px;
 }
 
-.fontsize {
-  font-size: 16px;
+.breadcrumbs {
+  font-size: 1rem;
 }
 
 @media (width >= 320px) {
-  .fontsize {
+  .breadcrumbs {
     font-size: calc(2.5vw + 8px);
   }
 }
 
 @media (width >= 400px) {
-  .fontsize {
+  .breadcrumbs {
     font-size: 18px;
   }
 }
 
 @media (width >= 1024px) {
-  .fontsize {
+  .breadcrumbs {
     font-size: calc(0.7813vw + 10px);
   }
 }
 
 @media (width >= 1280px) {
-  .fontsize {
+  .breadcrumbs {
     font-size: 20px;
   }
 }

--- a/src/components/breadcrumb/breadcrumb.css
+++ b/src/components/breadcrumb/breadcrumb.css
@@ -21,7 +21,8 @@ ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
-  overflow: hidden;
+
+  /* overflow: hidden; */
 }
 
 li,

--- a/src/components/breadcrumb/breadcrumb.css
+++ b/src/components/breadcrumb/breadcrumb.css
@@ -62,17 +62,12 @@ li:first-child {
 }
 
 .dropdown-content {
-  display: none;
   position: absolute;
   background-color: #fff;
   min-width: 160px;
   overflow: visible;
   box-shadow: var(--leu-box-shadow-short);
   z-index: 1;
-}
-
-.show {
-  display: block;
 }
 
 .visuallyhidden {

--- a/src/components/breadcrumb/breadcrumb.css
+++ b/src/components/breadcrumb/breadcrumb.css
@@ -21,15 +21,11 @@ ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
-}
-
-ol.hidden {
-  opacity: 0;
-  height: 0;
   overflow: hidden;
 }
 
-li, span {
+li,
+span {
   align-items: center;
   display: flex;
   min-height: 1.875rem;
@@ -39,26 +35,12 @@ li, span {
 a {
   color: inherit;
   text-decoration: none;
-  transition: color .1s ease;
+  transition: color 0.1s ease;
   white-space: nowrap;
 }
 
 li:first-child {
   font-family: var(--breadcrumb-font-black);
-}
-
-li.hidden {
-  display: none !important;
-}
-
-/* add space from arrows */
-ol.hidden li {
-  padding-left: 24px;
-}
-
-/* add space from ... */
-ol.hidden li:first-child {
-  padding-right: 24px;
 }
 
 .menu {
@@ -121,7 +103,7 @@ ol.hidden li:first-child {
 
 @media (width >= 1024px) {
   .fontsize {
-    font-size: calc(.7813vw + 10px);
+    font-size: calc(0.7813vw + 10px);
   }
 }
 

--- a/src/components/breadcrumb/stories/breadcrumb.stories.js
+++ b/src/components/breadcrumb/stories/breadcrumb.stories.js
@@ -25,7 +25,7 @@ function Template({ items, inverted }) {
     </div>
     <button
       @click=${() => {
-        document.getElementsByTagName("leu-breadcrumb")[0].setItems([
+        document.getElementsByTagName("leu-breadcrumb")[0].items = [
           { label: "Kanton Zürich", href: "https://zh.ch" },
           { label: "Bildung", href: "https://www.zh.ch/de/bildung.html" },
           {
@@ -36,7 +36,7 @@ function Template({ items, inverted }) {
             label: "Volksschule",
             href: "https://www.zh.ch/de/bildung/schulen/volksschule.html",
           },
-        ])
+        ]
       }}
       style="margin-top:50px;"
     >

--- a/src/components/breadcrumb/test/breadcrumb.test.js
+++ b/src/components/breadcrumb/test/breadcrumb.test.js
@@ -1,22 +1,141 @@
 import { html } from "lit"
-import { fixture, expect } from "@open-wc/testing"
+import { fixture, expect, aTimeout } from "@open-wc/testing"
+import { setViewport } from "@web/test-runner-commands"
 
 import "../leu-breadcrumb.js"
 
-async function defaultFixture() {
-  return fixture(html` <leu-breadcrumb /> `)
+const items = [
+  { label: "Kanton Zürich", href: "https://zh.ch" },
+  { label: "Gesundheit", href: "https://zh.ch/de/gesundheit.html" },
+  {
+    label: "Lebensmittel & Gebrauchsgegenstände",
+    href: "https://zh.ch/de/gesundheit/lebensmittel-gebrauchsgegenstaende.html",
+  },
+  {
+    label: "Lebensmittel",
+    href: "https://zh.ch/de/gesundheit/lebensmittel-gebrauchsgegenstaende/lebensmittel.html",
+  },
+  {
+    label: "Trinkwasser",
+    href: "https://zh.ch/de/gesundheit/lebensmittel-gebrauchsgegenstaende/lebensmittel.html",
+  },
+]
+
+async function defaultFixture(args = {}) {
+  return fixture(
+    html` <leu-breadcrumb .items="${args.items ?? items}"></leu-breadcrumb> `
+  )
 }
 
 describe("LeuBreadcrumb", () => {
   it("is a defined element", async () => {
     const el = customElements.get("leu-breadcrumb")
 
-    await expect(el).not.to.be.undefined
+    expect(el).not.to.be.undefined
   })
 
   it("passes the a11y audit", async () => {
     const el = await defaultFixture()
+    await expect(el).to.be.accessible()
+  })
 
-    await expect(el).shadowDom.to.be.accessible()
+  it("renders a list of items", async () => {
+    await setViewport({ width: 1024, height: 1024 })
+    const el = await defaultFixture()
+
+    const itemEls = el.shadowRoot.querySelectorAll("li")
+
+    expect(itemEls[0]).to.have.trimmed.text(items[0].label)
+    expect(itemEls[0].querySelector("a")).to.have.attribute(
+      "href",
+      items[0].href
+    )
+    expect(itemEls[1]).to.have.trimmed.text(items[1].label)
+    expect(itemEls[1].querySelector("a")).to.have.attribute(
+      "href",
+      items[1].href
+    )
+    expect(itemEls[2]).to.have.trimmed.text(items[2].label)
+    expect(itemEls[2].querySelector("a")).to.have.attribute(
+      "href",
+      items[2].href
+    )
+    expect(itemEls[3]).to.have.trimmed.text(items[3].label)
+    expect(itemEls[3].querySelector("a")).to.have.attribute(
+      "href",
+      items[3].href
+    )
+
+    expect(itemEls[4]).to.have.trimmed.text(items[4].label)
+    expect(itemEls[4].querySelector("a")).to.not.exist
+  })
+
+  it("hides the overflowing items when shrinking the viewport", async () => {
+    await setViewport({ width: 1024, height: 1024 })
+    const el = await defaultFixture()
+
+    let itemEls = el.shadowRoot.querySelectorAll("li")
+    expect(itemEls.length).to.equal(5)
+
+    await setViewport({ width: 768, height: 1024 })
+    await aTimeout(600)
+    await el.updateComplete
+    itemEls = el.shadowRoot.querySelectorAll("li")
+
+    expect(itemEls.length).to.equal(4)
+  })
+
+  it("shows all the items when viewport is enlarged", async () => {
+    await setViewport({ width: 768, height: 1024 })
+    const el = await defaultFixture()
+
+    let itemEls = el.shadowRoot.querySelectorAll("li")
+    expect(itemEls.length).to.equal(4)
+
+    await setViewport({ width: 1024, height: 1024 })
+    await aTimeout(600)
+    await el.updateComplete
+    itemEls = el.shadowRoot.querySelectorAll("li")
+
+    expect(itemEls.length).to.equal(5)
+  })
+
+  it("only shows the first item when the viewport is too small", async () => {
+    await setViewport({ width: 240, height: 1024 })
+    const el = await defaultFixture()
+
+    const itemEls = el.shadowRoot.querySelectorAll("li")
+    expect(itemEls.length).to.equal(1)
+
+    expect(itemEls[0]).to.have.trimmed.text(items[3].label)
+    expect(itemEls[0].querySelector("a")).to.have.attribute(
+      "href",
+      items[3].href
+    )
+  })
+
+  it("shows a dropdown toggle when items are hidden", async () => {
+    await setViewport({ width: 768, height: 1024 })
+    const el = await defaultFixture()
+
+    const dropdownToggle = el.shadowRoot.querySelector("li:nth-child(2) button")
+    expect(dropdownToggle).to.exist
+    expect(dropdownToggle).to.have.trimmed.text("…")
+  })
+
+  it("shows a dropdown when the toggle is clicked", async () => {
+    await setViewport({ width: 768, height: 1024 })
+    const el = await defaultFixture()
+
+    const dropdownToggle = el.shadowRoot.querySelector("li:nth-child(2) button")
+    dropdownToggle.click()
+
+    await el.updateComplete
+
+    const dropdown = el.shadowRoot.querySelectorAll("leu-menu")
+    expect(dropdown).to.exist
+
+    const dropdownItems = el.shadowRoot.querySelectorAll("leu-menu-item")
+    expect(dropdownItems.length).to.equal(2)
   })
 })


### PR DESCRIPTION
Refactor the whole breadcrumb component.

- Use ResizeObserver instead of resize event listener
- Not relying on setTimeout to wait for the component to be updated
- Use state to toggle the dropdown instead of manipulating the rendered element from within a method.
- Try to document the behaviour
- Add basic test cases