### PR TITLE
feat(dropdown): add click and keyup handler to close the dropdown

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -25,9 +25,29 @@ export class LeuDropdown extends LitElement {
     this.menuItems = []
   }
 
+  connectedCallback() {
+    super.connectedCallback()
+    this.addEventListener("keyup", this._keyUpHandler)
+    document.addEventListener("click", this._documentClickHandler)
+  }
+
   disconnectedCallback() {
     super.disconnectedCallback()
     this._removeMenuItemListeners()
+    this.removeEventListener("keyup", this._keyUpHandler)
+    document.removeEventListener("click", this._documentClickHandler)
+  }
+
+  _documentClickHandler = (event) => {
+    if (!this.contains(event.target)) {
+      this.expanded = false
+    }
+  }
+
+  _keyUpHandler(event) {
+    if (event.key === "Escape") {
+      this.expanded = false
+    }
   }
 
   _handleSlotChange() {


### PR DESCRIPTION
Added a click handler to the document to close the dropdown.
Added a keyup event handler that closes the dropdown when the escape key is pressed.