### PR TITLE
136 pagination reduce events

### DIFF
--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -118,23 +118,24 @@ export class LeuPagination extends LitElement {
         type="number"
       />
       <div class="label">von ${this.maxPage}</div>
-      <leu-button
-        icon="angleLeft"
-        variant="secondary"
-        @click=${(_) => {
-          this.numberUpdate(this.boundPage - 1)
-        }}
-        ?disabled=${this.firstPage}
-      ></leu-button>
-      <leu-button
-        icon="angleRight"
-        variant="secondary"
-        @click=${(_) => {
-          this.numberUpdate(this.boundPage + 1)
-        }}
-        ?disabled=${this.lastPage}
-        style="margin-left:4px;"
-      ></leu-button>
+      <div class="button-group">
+        <leu-button
+          icon="angleLeft"
+          variant="secondary"
+          @click=${(_) => {
+            this.numberUpdate(this.boundPage - 1)
+          }}
+          ?disabled=${this.firstPage}
+        ></leu-button>
+        <leu-button
+          icon="angleRight"
+          variant="secondary"
+          @click=${(_) => {
+            this.numberUpdate(this.boundPage + 1)
+          }}
+          ?disabled=${this.lastPage}
+        ></leu-button>
+      </div>
     `
   }
 }

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -25,57 +25,83 @@ export class LeuPagination extends LitElement {
   }
 
   static properties = {
-    page: { type: Number, reflect: true },
+    defaultPage: { type: Number, reflect: true },
     itemsPerPage: { type: Number, reflect: true },
     numOfItems: { type: Number, reflect: true },
+
+    /**
+     * Internal page state that contains an
+     * already clamped page number. Should only
+     * be accessed through the `page` getter and
+     * setter.
+     * @type {Number}
+     * @internal
+     */
+    _page: { state: true },
   }
 
   constructor() {
     super()
-    /** @type {number} */
-    this.page = 1
-    /** @type {number} */
+
+    /** @type {Number} */
     this.numOfItems = 1
-    /** @type {number} */
+    /** @type {Number} */
     this.itemsPerPage = 1
+    /** @type {Number} */
+    this._page = 1
   }
 
-  get maxPage() {
+  attributeChangedCallback(name, oldVal, newVal) {
+    super.attributeChangedCallback(name, oldVal, newVal)
+
+    if (name === "defaultpage" && newVal !== oldVal) {
+      this.page = parseInt(newVal, 10)
+    }
+  }
+
+  get page() {
+    return this._page
+  }
+
+  set page(page) {
+    this._page = this._clampPage(page)
+  }
+
+  get startIndex() {
+    return (this.page - 1) * this.itemsPerPage
+  }
+
+  get endIndex() {
+    return Math.min(this.startIndex + this.itemsPerPage, this.numOfItems)
+  }
+
+  get _maxPage() {
     return Math.ceil(this.numOfItems / this.itemsPerPage)
   }
 
-  get firstPage() {
-    return this.boundPage === MIN_PAGE
+  _isFirstPage() {
+    return this.page === MIN_PAGE
   }
 
-  get lastPage() {
-    return this.boundPage === this.maxPage
+  _isLastPage() {
+    return this.page === this._maxPage
   }
 
-  /**
-   * The boundPage getter is necessary to ensure that the current page (this.page) is always within the valid range of pages.
-   * It prevents the page number from going below the minimum page limit (MIN_PAGE) or above the maximum page limit (this.maxPage).
-   * This is important for the correct functioning of the pagination system, as it prevents users from navigating to non-existent pages.
-   *
-   * @returns {number}
-   */
-  get boundPage() {
-    return Math.min(Math.max(this.page, MIN_PAGE), this.maxPage)
+  _clampPage(page) {
+    return Math.min(Math.max(page, MIN_PAGE), this._maxPage)
   }
 
-  numberUpdate(number) {
+  _updatePage(page) {
     const prevPage = this.page
-    this.page = number
+    this.page = this._clampPage(page)
 
     if (this.page !== prevPage) {
-      const startIndex = (this.boundPage - 1) * this.itemsPerPage
-      const endIndex = Math.min(startIndex + this.itemsPerPage, this.numOfItems)
       this.dispatchEvent(
         new CustomEvent("leu:pagechange", {
           detail: {
-            startIndex,
-            endIndex,
-            page: this.boundPage,
+            startIndex: this.startIndex,
+            endIndex: this.endIndex,
+            page: this.page,
           },
           bubbles: false,
         })
@@ -83,25 +109,25 @@ export class LeuPagination extends LitElement {
     }
   }
 
-  change(event) {
-    this.numberUpdate(parseInt(event.target.value, 10) || 0)
+  _handleChange(event) {
+    this._updatePage(parseInt(event.target.value, 10) || 0)
   }
 
-  input(event) {
+  _handleInput(event) {
     if (event.target.value !== "") {
       event.preventDefault()
-      this.change(event)
+      this._handleChange(event)
     }
   }
 
-  keydown(event) {
+  _handleKeyDown(event) {
     if (event.key === "ArrowUp") {
       event.preventDefault()
-      this.numberUpdate(this.boundPage + 1)
+      this._updatePage(this.page + 1)
     }
     if (event.key === "ArrowDown") {
       event.preventDefault()
-      this.numberUpdate(this.boundPage - 1)
+      this._updatePage(this.page - 1)
     }
   }
 
@@ -110,30 +136,30 @@ export class LeuPagination extends LitElement {
       <input
         class="input"
         min=${MIN_PAGE}
-        max=${this.maxPage}
-        .value=${live(this.boundPage.toString())}
-        @input=${this.input}
-        @change=${this.change}
-        @keydown=${this.keydown}
+        max=${this._maxPage}
+        .value=${live(this.page.toString())}
+        @input=${this._handleInput}
+        @change=${this._handleChange}
+        @keydown=${this._handleKeyDown}
         type="number"
       />
-      <div class="label">von ${this.maxPage}</div>
+      <div class="label">von ${this._maxPage}</div>
       <div class="button-group">
         <leu-button
           icon="angleLeft"
           variant="secondary"
           @click=${(_) => {
-            this.numberUpdate(this.boundPage - 1)
+            this._updatePage(this.page - 1)
           }}
-          ?disabled=${this.firstPage}
+          ?disabled=${this._isFirstPage()}
         ></leu-button>
         <leu-button
           icon="angleRight"
           variant="secondary"
           @click=${(_) => {
-            this.numberUpdate(this.boundPage + 1)
+            this._updatePage(this.page + 1)
           }}
-          ?disabled=${this.lastPage}
+          ?disabled=${this._isLastPage()}
         ></leu-button>
       </div>
     `

--- a/src/components/pagination/pagination.css
+++ b/src/components/pagination/pagination.css
@@ -47,3 +47,8 @@
   color: var(--leu-color-black-transp-60);
   white-space: nowrap;
 }
+
+.button-group {
+  display: flex;
+  gap: 0.25rem;
+}

--- a/src/components/pagination/stories/pagination.stories.js
+++ b/src/components/pagination/stories/pagination.stories.js
@@ -1,8 +1,11 @@
 import { html } from "lit"
+import { action } from "@storybook/addon-actions"
+
 import "../leu-pagination.js"
 
 // https://stackoverflow.com/questions/72566428/storybook-angular-how-to-dynamically-update-args-from-the-template
 import { UPDATE_STORY_ARGS } from "@storybook/core-events" // eslint-disable-line
+import { ifDefined } from "lit/directives/if-defined.js"
 function updateStorybookArgss(id, args) {
   const channel = window.__STORYBOOK_ADDONS_CHANNEL__
   channel.emit(UPDATE_STORY_ARGS, {
@@ -56,6 +59,9 @@ const items = [
 export default {
   title: "Pagination",
   component: "leu-pagination",
+  args: {
+    onPageChange: action("leu:pagechange"),
+  },
   parameters: {
     design: {
       type: "figma",
@@ -64,15 +70,20 @@ export default {
   },
 }
 
-function Template({ startIndex, endIndex }, { id }) {
+function Template(
+  { startIndex, endIndex, onPageChange, itemsPerPage, defaultPage },
+  { id }
+) {
   return html`
     ${items
       .slice(startIndex, endIndex)
       .map((item) => html`<div>${item.label}</div>`)}
     <leu-pagination
       numOfItems=${items.length}
-      itemsPerPage="5"
+      itemsPerPage=${ifDefined(itemsPerPage)}
+      defaultPage=${ifDefined(defaultPage)}
       @leu:pagechange=${(e) => {
+        onPageChange(e)
         updateStorybookArgss(id, {
           startIndex: e.detail.startIndex,
           endIndex: e.detail.endIndex,
@@ -87,4 +98,6 @@ export const Regular = Template.bind({})
 Regular.args = {
   startIndex: 0,
   endIndex: 5,
+  itemsPerPage: 5,
+  // defaultPage: 2,
 }

--- a/src/components/pagination/test/pagination.test.js
+++ b/src/components/pagination/test/pagination.test.js
@@ -10,7 +10,7 @@ async function defaultFixture(args = {}) {
   return fixture(html`<leu-pagination
     numOfItems=${ifDefined(args.numOfItems)}
     itemsPerPage=${ifDefined(args.itemsPerPage)}
-    page=${ifDefined(args.page)}
+    defaultPage=${ifDefined(args.defaultPage)}
   >
   </leu-pagination>`)
 }
@@ -26,7 +26,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 1,
+      defaultPage: 1,
     })
 
     await expect(el).shadowDom.to.be.accessible()
@@ -36,7 +36,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 1,
+      defaultPage: 1,
     })
 
     const previous = el.shadowRoot.querySelectorAll("leu-button")[0]
@@ -48,7 +48,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 14,
+      defaultPage: 14,
     })
 
     const next = el.shadowRoot.querySelectorAll("leu-button")[1]
@@ -60,7 +60,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 1,
+      defaultPage: 1,
     })
 
     const label = el.shadowRoot.querySelectorAll(".label")
@@ -72,7 +72,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 2,
+      defaultPage: 2,
     })
 
     const input = el.shadowRoot.querySelector("input")
@@ -84,7 +84,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 1,
+      defaultPage: 1,
     })
 
     const next = el.shadowRoot.querySelectorAll("leu-button")[1]
@@ -99,7 +99,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 10,
+      defaultPage: 10,
     })
 
     const next = el.shadowRoot.querySelectorAll("leu-button")[0]
@@ -114,7 +114,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 1,
+      defaultPage: 1,
     })
 
     el.focus()
@@ -131,7 +131,7 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 98,
       itemsPerPage: 7,
-      page: 13,
+      defaultPage: 13,
     })
 
     el.focus()
@@ -148,18 +148,18 @@ describe("LeuPagination", () => {
     const el = await defaultFixture({
       numOfItems: 50,
       itemsPerPage: 10,
-      page: 6,
+      defaultPage: 6,
     })
 
     const input = el.shadowRoot.querySelector("input")
 
-    expect(el.boundPage).to.equal(5)
+    expect(el.page).to.equal(5)
     expect(input.value).to.equal("5")
 
     el.page = 0
     await elementUpdated(el)
 
-    expect(el.boundPage).to.equal(1)
+    expect(el.page).to.equal(1)
     expect(input.value).to.equal("1")
 
     el.focus()
@@ -169,7 +169,7 @@ describe("LeuPagination", () => {
     })
     await elementUpdated(el)
 
-    expect(el.boundPage).to.equal(1)
+    expect(el.page).to.equal(1)
     expect(input.value).to.equal("1")
 
     await sendKeys({ press: "ArrowUp" })
@@ -178,7 +178,7 @@ describe("LeuPagination", () => {
     await sendKeys({ press: "ArrowUp" })
     await sendKeys({ press: "ArrowUp" })
 
-    expect(el.boundPage).to.equal(5)
+    expect(el.page).to.equal(5)
     expect(input.value).to.equal("5")
   })
 


### PR DESCRIPTION
Refactor the logic that the value of a state is clamped before it is stored. Until now it was always clamped before it was retrieved.
This also ensures that the page value can be accessed via a `page` property from the outside.