### PR TITLE
150 button group nested interactive controls

### DIFF
--- a/src/components/button-group/ButtonGroup.js
+++ b/src/components/button-group/ButtonGroup.js
@@ -40,12 +40,12 @@ export class LeuButtonGroup extends LitElement {
           (item) =>
             html`
               <leu-button
-                variant=${this.value === item ? "primary" : "secondary"}
+                variant="secondary"
                 @click=${() => {
                   this._setValue(item)
                 }}
-                role="menuitemradio"
-                aria-checked=${this.value === item}
+                componentrole="menuitemradio"
+                ?active=${this.value === item}
               >
                 ${item}
               </leu-button>

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -24,7 +24,7 @@ const BUTTON_TYPES = ["button", "submit", "reset"]
 Object.freeze(BUTTON_TYPES)
 export { BUTTON_TYPES }
 
-export const BUTTON_EXPANDED_OPTIONS = ["open", "closed"]
+export const BUTTON_EXPANDED_OPTIONS = ["true", "false"]
 Object.freeze(BUTTON_EXPANDED_OPTIONS)
 
 /**
@@ -80,6 +80,7 @@ export class LeuButton extends LitElement {
     size: { type: String, reflect: true },
     variant: { type: String, reflect: true },
     type: { type: String, reflect: true },
+    componentRole: { type: String, reflect: true },
 
     disabled: { type: Boolean, reflect: true },
     round: { type: Boolean, reflect: true },
@@ -87,9 +88,6 @@ export class LeuButton extends LitElement {
     inverted: { type: Boolean, reflect: true },
     expanded: { type: String, reflect: true },
     fluid: { type: Boolean, reflect: true },
-
-    componentRole: { type: String, reflect: true },
-    controls: { type: String, reflect: true },
   }
 
   constructor() {
@@ -121,7 +119,7 @@ export class LeuButton extends LitElement {
 
     /**
      * Only taken into account if variant is "ghost"
-     * @type {("open" | "closed" | undefined)}
+     * @type {("true" | "false" | undefined)}
      */
     this.expanded = undefined
   }
@@ -164,7 +162,6 @@ export class LeuButton extends LitElement {
     const attributes = {
       role: this.componentRole,
       label: this.label,
-      controls: this.controls,
     }
 
     if (this.componentRole) {
@@ -173,10 +170,6 @@ export class LeuButton extends LitElement {
       } else if (ARIA_ROLES_SELECTED.includes(this.componentRole)) {
         attributes.selected = this.active ? "true" : "false"
       }
-    }
-
-    if (typeof this.expanded !== "undefined") {
-      attributes.expanded = this.expanded === "open" ? "true" : "false"
     }
 
     return attributes
@@ -197,8 +190,6 @@ export class LeuButton extends LitElement {
     return html`
       <button
         aria-label=${ifDefined(aria.label)}
-        aria-expanded=${ifDefined(aria.expanded)}
-        aria-controls=${ifDefined(aria.controls)}
         aria-selected=${ifDefined(aria.selected)}
         aria-checked=${ifDefined(aria.checked)}
         role=${ifDefined(aria.role)}

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -28,6 +28,33 @@ export const BUTTON_EXPANDED_OPTIONS = ["open", "closed"]
 Object.freeze(BUTTON_EXPANDED_OPTIONS)
 
 /**
+ * All roles that are associated with a aria-checked attribute
+ * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked
+ */
+const ARIA_ROLES_CHECKED = [
+  "checkbox",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "switch",
+]
+
+/**
+ * All roles that are associated with a aria-selected attribute
+ * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected
+ */
+const ARIA_ROLES_SELECTED = [
+  "gridcell",
+  "option",
+  "row",
+  "tab",
+  "columnheader",
+  "rowheader",
+  "treeitem",
+]
+
+/**
  * @tagname leu-button
  */
 export class LeuButton extends LitElement {
@@ -60,6 +87,9 @@ export class LeuButton extends LitElement {
     inverted: { type: Boolean, reflect: true },
     expanded: { type: String, reflect: true },
     fluid: { type: Boolean, reflect: true },
+
+    componentRole: { type: String, reflect: true },
+    controls: { type: String, reflect: true },
   }
 
   constructor() {
@@ -130,8 +160,31 @@ export class LeuButton extends LitElement {
     return nothing
   }
 
+  getAriaAttributes() {
+    const attributes = {
+      role: this.componentRole,
+      label: this.label,
+      controls: this.controls,
+    }
+
+    if (this.componentRole) {
+      if (ARIA_ROLES_CHECKED.includes(this.componentRole)) {
+        attributes.checked = this.active ? "true" : "false"
+      } else if (ARIA_ROLES_SELECTED.includes(this.componentRole)) {
+        attributes.selected = this.active ? "true" : "false"
+      }
+    }
+
+    if (typeof this.expanded !== "undefined") {
+      attributes.expanded = this.expanded === "open" ? "true" : "false"
+    }
+
+    return attributes
+  }
+
   render() {
     const hasContent = this.hasSlotController.test("[default]")
+    const aria = this.getAriaAttributes()
 
     const cssClasses = {
       icon: !hasContent && this.icon,
@@ -143,7 +196,12 @@ export class LeuButton extends LitElement {
     }
     return html`
       <button
-        aria-label=${ifDefined(this.label)}
+        aria-label=${ifDefined(aria.label)}
+        aria-expanded=${ifDefined(aria.expanded)}
+        aria-controls=${ifDefined(aria.controls)}
+        aria-selected=${ifDefined(aria.selected)}
+        aria-checked=${ifDefined(aria.checked)}
+        role=${ifDefined(aria.role)}
         class=${classMap(cssClasses)}
         ?disabled=${this.disabled}
         type=${this.type}

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -76,6 +76,10 @@ button.primary.active {
   background: var(--leu-color-black-100);
 }
 
+button.primary.active:hover {
+  background: var(--leu-color-black-transp-80);
+}
+
 button.primary:disabled {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-transp-20);
@@ -95,6 +99,10 @@ button.secondary:hover {
 button.secondary.active {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-100);
+}
+
+button.secondary.active:hover {
+  background: var(--leu-color-black-transp-80);
 }
 
 button.secondary:disabled {

--- a/src/components/button/test/button.test.js
+++ b/src/components/button/test/button.test.js
@@ -100,7 +100,7 @@ describe("LeuButton", () => {
     const button = el.shadowRoot.querySelector("button")
 
     expect(button).dom.to.equal(
-      "<button class='ghost regular'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot><div class='icon-wrapper icon-wrapper--expanded'><svg width='24' height='24'><path /></svg></div></div>",
+      "<button class='ghost regular' aria-expanded='true'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot><div class='icon-wrapper icon-wrapper--expanded'><svg width='24' height='24'><path /></svg></div></div>",
       { ignoreAttributes: ["d", "type", "width", "height"] }
     )
 
@@ -109,7 +109,7 @@ describe("LeuButton", () => {
     await elementUpdated(el)
 
     expect(button).dom.to.equal(
-      "<button class='primary regular'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot></div>",
+      "<button class='primary regular' aria-expanded='true'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot></div>",
       { ignoreAttributes: ["d", "type"] }
     )
   })
@@ -133,6 +133,99 @@ describe("LeuButton", () => {
     await elementUpdated(el)
 
     expect(button).to.not.have.attribute("disabled")
+  })
+
+  it("sets the aria-expanded attribute", async () => {
+    const el = await fixture(
+      html` <leu-button icon="addNew" variant="ghost" expanded="open"
+        >Sichern</leu-button
+      >`
+    )
+
+    const button = el.shadowRoot.querySelector("button")
+
+    expect(button).to.have.attribute("aria-expanded", "true")
+
+    el.expanded = "closed"
+    await elementUpdated(el)
+
+    expect(button).to.have.attribute("aria-expanded", "false")
+
+    el.expanded = undefined
+    await elementUpdated(el)
+
+    expect(button).to.not.have.attribute("aria-expanded")
+  })
+
+  it("reflects the aria-controls attribute", async () => {
+    const el = await fixture(
+      html` <leu-button
+        icon="addNew"
+        variant="ghost"
+        controls="id-of-content"
+        expanded="open"
+        >Sichern</leu-button
+      >`
+    )
+
+    const button = el.shadowRoot.querySelector("button")
+
+    expect(button).to.have.attribute("aria-controls", "id-of-content")
+  })
+
+  it("reflects the role attribute", async () => {
+    const el = await fixture(
+      html` <leu-button
+        icon="addNew"
+        variant="ghost"
+        componentRole="menuitemradio"
+        >Sichern</leu-button
+      >`
+    )
+
+    const button = el.shadowRoot.querySelector("button")
+
+    expect(button).to.have.attribute("role", "menuitemradio")
+  })
+
+  it("sets the either checked or selected attribute depending on the role", async () => {
+    const el = await fixture(
+      html` <leu-button
+        icon="addNew"
+        variant="ghost"
+        componentRole="menuitemradio"
+        active
+        >Sichern</leu-button
+      >`
+    )
+
+    const button = el.shadowRoot.querySelector("button")
+
+    expect(button).to.have.attribute("aria-checked", "true")
+    expect(button).to.not.have.attribute("aria-selected")
+
+    el.componentRole = "tab"
+
+    await elementUpdated(el)
+
+    expect(button).to.have.attribute("aria-selected", "true")
+    expect(button).to.not.have.attribute("aria-checked")
+
+    el.componentRole = "checkbox"
+    el.active = false
+
+    await elementUpdated(el)
+
+    expect(button).to.have.attribute("aria-checked", "false")
+    expect(button).to.not.have.attribute("aria-selected")
+
+    el.componentRole = undefined
+    el.active = true
+
+    await elementUpdated(el)
+
+    expect(button).to.not.have.attribute("aria-checked")
+    expect(button).to.not.have.attribute("aria-selected")
   })
 
   it("dispatches the click event", async () => {

--- a/src/components/button/test/button.test.js
+++ b/src/components/button/test/button.test.js
@@ -92,7 +92,7 @@ describe("LeuButton", () => {
 
   it("renders the expanded icon only when the variant is ghost", async () => {
     const el = await fixture(
-      html` <leu-button icon="addNew" variant="ghost" expanded="open"
+      html` <leu-button icon="addNew" variant="ghost" expanded="true"
         >Sichern</leu-button
       >`
     )
@@ -100,7 +100,7 @@ describe("LeuButton", () => {
     const button = el.shadowRoot.querySelector("button")
 
     expect(button).dom.to.equal(
-      "<button class='ghost regular' aria-expanded='true'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot><div class='icon-wrapper icon-wrapper--expanded'><svg width='24' height='24'><path /></svg></div></div>",
+      "<button class='ghost regular'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot><div class='icon-wrapper icon-wrapper--expanded'><svg width='24' height='24'><path /></svg></div></div>",
       { ignoreAttributes: ["d", "type", "width", "height"] }
     )
 
@@ -109,7 +109,7 @@ describe("LeuButton", () => {
     await elementUpdated(el)
 
     expect(button).dom.to.equal(
-      "<button class='primary regular' aria-expanded='true'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot></div>",
+      "<button class='primary regular'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot></div>",
       { ignoreAttributes: ["d", "type"] }
     )
   })
@@ -120,7 +120,7 @@ describe("LeuButton", () => {
         icon="addNew"
         label="Sichern"
         variant="ghost"
-        expanded="open"
+        expanded="true"
         disabled
       ></leu-button>`
     )
@@ -133,44 +133,6 @@ describe("LeuButton", () => {
     await elementUpdated(el)
 
     expect(button).to.not.have.attribute("disabled")
-  })
-
-  it("sets the aria-expanded attribute", async () => {
-    const el = await fixture(
-      html` <leu-button icon="addNew" variant="ghost" expanded="open"
-        >Sichern</leu-button
-      >`
-    )
-
-    const button = el.shadowRoot.querySelector("button")
-
-    expect(button).to.have.attribute("aria-expanded", "true")
-
-    el.expanded = "closed"
-    await elementUpdated(el)
-
-    expect(button).to.have.attribute("aria-expanded", "false")
-
-    el.expanded = undefined
-    await elementUpdated(el)
-
-    expect(button).to.not.have.attribute("aria-expanded")
-  })
-
-  it("reflects the aria-controls attribute", async () => {
-    const el = await fixture(
-      html` <leu-button
-        icon="addNew"
-        variant="ghost"
-        controls="id-of-content"
-        expanded="open"
-        >Sichern</leu-button
-      >`
-    )
-
-    const button = el.shadowRoot.querySelector("button")
-
-    expect(button).to.have.attribute("aria-controls", "id-of-content")
   })
 
   it("reflects the role attribute", async () => {

--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -87,7 +87,7 @@ export class LeuDropdown extends LitElement {
           slot="anchor"
           icon="download"
           variant="ghost"
-          expanded=${this.expanded ? "open" : "closed"}
+          expanded=${this.expanded ? "true" : "false"}
           aria-expanded=${this.expanded ? "true" : "false"}
           aria-controls="content"
           ?active=${this.expanded}


### PR DESCRIPTION
Until now the only way to set an aria state or role attribute to a button was to add it directly to the `leu-button` element.
But because the `leu-button` element will render a native `button` element we end up with [nested interactive controls](https://dequeuniversity.com/rules/axe/4.7/nested-interactive?application=axeAPI)).

The role of the underlying button can now be defined with the `componentRole` property.
A set of aria state attributes will be implied depending on the current properties.
e.g. `expanded` sets `aria-expanded`
`active` sets `aria-selected` or `aria-checked` depending on the defined `role`

This solution is not very flexible but the most easy one to implement at the moment. I think most use cases can be implemented with this structure.

A more generic solution would be to implement a base button component as a building block for other components. 
Inside the default slot a native button element with arbitrary attributes can be rendered.
This way we could still reuse all the styling but also have the most flexibility.
```
<leu-base-button>
  <button aria-checked="mixed" role="checkbox">Option 1</button>
</leu-button>
```