### PR TITLE
152 buttongroup use slots for items

### DIFF
--- a/src/components/button-group/ButtonGroup.js
+++ b/src/components/button-group/ButtonGroup.js
@@ -1,6 +1,5 @@
 import { html, LitElement } from "lit"
 import styles from "./button-group.css"
-import "../button/leu-button.js"
 
 /**
  * @tagname leu-button-group
@@ -22,7 +21,7 @@ export class LeuButtonGroup extends LitElement {
    * @returns {string}
    */
   static getButtonValue(button) {
-    return button.getAttribute("value") ?? button.textContent
+    return button.getAttribute("value") ?? button.innerText.trim()
   }
 
   get value() {
@@ -55,9 +54,8 @@ export class LeuButtonGroup extends LitElement {
 
     this._items.forEach((item) => {
       /* eslint-disable no-param-reassign */
-      item.addEventListener("click", this._handleButtonClick)
-
-      item.componentrole = "menuitemradio"
+      item.addEventListener("click", () => this._handleButtonClick(item))
+      item.componentRole = "menuitemradio"
 
       /**
        * In case there are multiple active buttons
@@ -73,9 +71,7 @@ export class LeuButtonGroup extends LitElement {
     })
   }
 
-  _handleButtonClick(event) {
-    const button = event.target
-
+  _handleButtonClick(button) {
     if (!button.active) {
       this.value = LeuButtonGroup.getButtonValue(button)
 

--- a/src/components/button-group/ButtonGroup.js
+++ b/src/components/button-group/ButtonGroup.js
@@ -4,53 +4,95 @@ import "../button/leu-button.js"
 
 /**
  * @tagname leu-button-group
+ * @slot - Slot for the buttons
+ * @prop {string} value - The value of the currenty selected (active) button
+ * @fires input - When the value of the group changes by clicking a button
  */
 export class LeuButtonGroup extends LitElement {
   static styles = styles
 
-  static properties = {
-    items: { type: Array, reflect: true },
-    value: { type: String, reflect: true },
-  }
-
   constructor() {
     super()
-    /** @type {Array} */
-    this.items = []
-    /** @type {string} */
-    this.value = null
+
+    this._items = []
   }
 
-  _setValue(newValue) {
-    this.value = newValue
+  /**
+   * @param {HTMLElement} button
+   * @returns {string}
+   */
+  static getButtonValue(button) {
+    return button.getAttribute("value") ?? button.textContent
+  }
 
-    this.dispatchEvent(
-      new CustomEvent("input", {
-        bubbles: true,
-        composed: true,
-        detail: { value: newValue },
-      })
-    )
+  get value() {
+    const activeButton = this._items.find((item) => item.active)
+    return activeButton ? LeuButtonGroup.getButtonValue(activeButton) : null
+  }
+
+  set value(newValue) {
+    this._items.forEach((item) => {
+      /* eslint-disable no-param-reassign */
+      item.active = LeuButtonGroup.getButtonValue(item) === newValue
+      /* eslint-enable no-param-reassign */
+    })
+  }
+
+  _handleSlotChange() {
+    /**
+     * Remove all event listeners that were added before.
+     * Just because a slotchange event was fired, it doesn't mean that all of the
+     * children of the slot have changed.
+     */
+    this._items.forEach((item) => {
+      item.removeEventListener("click", this._handleButtonClick)
+    })
+
+    const slot = this.shadowRoot.querySelector("slot")
+    this._items = slot.assignedElements({ flatten: true })
+
+    let foundActiveButtonBefore = false
+
+    this._items.forEach((item) => {
+      /* eslint-disable no-param-reassign */
+      item.addEventListener("click", this._handleButtonClick)
+
+      item.componentrole = "menuitemradio"
+
+      /**
+       * In case there are multiple active buttons
+       * only the first one will be kept active.
+       */
+      if (item.active && foundActiveButtonBefore) {
+        item.active = false
+      } else if (item.active) {
+        foundActiveButtonBefore = true
+      }
+
+      /* eslint-enable no-param-reassign */
+    })
+  }
+
+  _handleButtonClick(event) {
+    const button = event.target
+
+    if (!button.active) {
+      this.value = LeuButtonGroup.getButtonValue(button)
+
+      this.dispatchEvent(
+        new CustomEvent("input", {
+          bubbles: true,
+          composed: true,
+          detail: { value: LeuButtonGroup.getButtonValue(button) },
+        })
+      )
+    }
   }
 
   render() {
     return html`
       <div role="menubar" class="group">
-        ${this.items.map(
-          (item) =>
-            html`
-              <leu-button
-                variant="secondary"
-                @click=${() => {
-                  this._setValue(item)
-                }}
-                componentrole="menuitemradio"
-                ?active=${this.value === item}
-              >
-                ${item}
-              </leu-button>
-            `
-        )}
+        <slot @slotchange=${this._handleSlotChange}></slot>
       </div>
     `
   }

--- a/src/components/button-group/stories/button-group.stories.js
+++ b/src/components/button-group/stories/button-group.stories.js
@@ -1,5 +1,6 @@
 import { html } from "lit"
 import "../leu-button-group.js"
+import "../../button/leu-button.js"
 
 // https://stackoverflow.com/questions/72566428/storybook-angular-how-to-dynamically-update-args-from-the-template
 import { UPDATE_STORY_ARGS } from "@storybook/core-events" // eslint-disable-line
@@ -23,10 +24,9 @@ export default {
 }
 
 function Template({ items, value }, { id }) {
-  return html`
-    <leu-button-group
+  return html` <leu-button-group
       .value=${value}
-      @click=${(event) => {
+      @input=${(event) => {
         updateStorybookArgss(id, {
           value: event.target.value,
         })
@@ -34,15 +34,17 @@ function Template({ items, value }, { id }) {
     >
       ${items.map(
         (i) =>
-          html`<leu-button variant="secondary" ?active=${value === i} value=${i}
-            >${i}</leu-button
-          >`
+          html`<leu-button
+            variant="secondary"
+            ?active=${value === i}
+            value=${`${i}-attr`}
+            >${i}
+          </leu-button>`
       )}
     </leu-button-group>
     <br />
     <br />
-    <pre>value = '${value}'</pre>
-  `
+    <pre>value = '${value}'</pre>`
 }
 
 export const Regular = Template.bind({})

--- a/src/components/button-group/stories/button-group.stories.js
+++ b/src/components/button-group/stories/button-group.stories.js
@@ -25,7 +25,6 @@ export default {
 function Template({ items, value }, { id }) {
   return html`
     <leu-button-group
-      .items=${items}
       .value=${value}
       @click=${(event) => {
         updateStorybookArgss(id, {
@@ -33,6 +32,12 @@ function Template({ items, value }, { id }) {
         })
       }}
     >
+      ${items.map(
+        (i) =>
+          html`<leu-button variant="secondary" ?active=${value === i} value=${i}
+            >${i}</leu-button
+          >`
+      )}
     </leu-button-group>
     <br />
     <br />


### PR DESCRIPTION
Rewrite component so that items can be placed directly into the default slot and don't have to be defined as a list in a property.