### PR TITLE
168 chips text overflow

### DIFF
--- a/src/components/accordion/stories/accordion.stories.js
+++ b/src/components/accordion/stories/accordion.stories.js
@@ -8,7 +8,8 @@ export default {
   component: "leu-accordion",
   argTypes: {
     headingLevel: {
-      options: [0, 1, 2, 3, 4, 5, 6],
+      control: "select",
+      options: [1, 2, 3, 4, 5, 6],
     },
     content: {
       control: {

--- a/src/components/chip/ChipGroup.js
+++ b/src/components/chip/ChipGroup.js
@@ -1,4 +1,5 @@
-import { LitElement, html } from "lit"
+import { LitElement } from "lit"
+import { html, unsafeStatic } from "lit/static-html.js"
 import styles from "./chip-group.css"
 
 /* Figma https://www.figma.com/file/d6Pv21UVUbnBs3AdcZijHmbN/KTZH-Design-System?type=design&node-id=131766-248643&mode=design&t=Kjo5VDiqivihn8dh-11 */
@@ -11,6 +12,7 @@ export const SELECTION_MODES = {
 
 /**
  * @slot - Place leu-chip-* elements inside this slot
+ * @cssproperty --leu-chip-group-gap - The gap between the chips
  * @tagname leu-chip-group
  */
 export class LeuChipGroup extends LitElement {
@@ -18,10 +20,15 @@ export class LeuChipGroup extends LitElement {
 
   static properties = {
     selectionMode: { type: String, attribute: "selection-mode", reflect: true },
+    headingLevel: { type: Number, attribute: "heading-level", reflect: true },
+    label: { type: String, reflect: true },
   }
 
   constructor() {
     super()
+
+    this.headingLevel = 2
+    this.label = ""
 
     /** @internal */
     this.items = []
@@ -43,6 +50,22 @@ export class LeuChipGroup extends LitElement {
     return this.items.filter((i) => i.selected).map((i) => i.value)
   }
 
+  /**
+   * Determines the heading tag of the accordion toggle.
+   * The headingLevel shouldn't be used directly to render the heading tag
+   * in order to avoid XSS issues.
+   * @returns {String} The heading tag of the accordion toggle.
+   * @internal
+   */
+  _getHeadingTag() {
+    let level = 2
+    if (this.headingLevel > 0 && this.headingLevel < 7) {
+      level = this.headingLevel
+    }
+
+    return `h${level}`
+  }
+
   /** @internal */
   handleInput = (e) => {
     if (this.selectionMode === SELECTION_MODES.single) {
@@ -61,6 +84,21 @@ export class LeuChipGroup extends LitElement {
   }
 
   render() {
-    return html`<slot @slotchange=${this.handleSlotChange}></slot>`
+    const hTag = this._getHeadingTag()
+
+    /* The eslint rules don't recognize html import from lit/static-html.js */
+    /* eslint-disable lit/binding-positions, lit/no-invalid-html */
+    return html`
+      ${this.label
+        ? html`<${unsafeStatic(hTag)} class="label">
+            <span class="label">${this.label}</span>
+          </${unsafeStatic(hTag)}>`
+        : ""}
+      <slot
+        class="group"
+        part="group"
+        @slotchange=${this.handleSlotChange}
+      ></slot>
+    `
   }
 }

--- a/src/components/chip/ChipGroup.js
+++ b/src/components/chip/ChipGroup.js
@@ -19,6 +19,7 @@ export class LeuChipGroup extends LitElement {
   static styles = styles
 
   static properties = {
+    inverted: { type: Boolean, reflect: true },
     selectionMode: { type: String, attribute: "selection-mode", reflect: true },
     headingLevel: { type: Number, attribute: "heading-level", reflect: true },
     label: { type: String, reflect: true },

--- a/src/components/chip/ChipGroup.js
+++ b/src/components/chip/ChipGroup.js
@@ -27,6 +27,7 @@ export class LeuChipGroup extends LitElement {
   constructor() {
     super()
 
+    this.inverted = false
     this.headingLevel = 2
     this.label = ""
 

--- a/src/components/chip/chip-group.css
+++ b/src/components/chip/chip-group.css
@@ -1,5 +1,15 @@
-:host {
+.label {
+  margin: 0 0 0.5rem;
+  font: var(--leu-t-curve-35-black-font);
+  color: var(--leu-color-black-100);
+}
+
+:host([inverted]) .label {
+  color: var(--leu-color-black-0);
+}
+
+.group {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--leu-chip-group-gap, 0.5rem);
 }

--- a/src/components/chip/chip.css
+++ b/src/components/chip/chip.css
@@ -29,6 +29,9 @@
   --chip-radio-background: var(--chip-radio-background-default);
 
   font-family: var(--chip-font-regular);
+
+  /* Allow shrinking to achieve text truncation (ellipsis) */
+  min-width: 0;
 }
 
 :host([inverted]) {
@@ -61,8 +64,11 @@
   cursor: pointer;
 
   display: inline-flex;
-  align-items: center;
   gap: 0.5rem;
+
+  /* Allow shrinking to achieve text truncation (ellipsis) */
+  min-width: 0;
+  max-width: 100%;
 }
 
 .button:hover,
@@ -109,6 +115,7 @@
 
 :host([variant="radio"]) .button::before {
   content: "";
+  flex: 0 0 1rem;
   width: 1rem;
   height: 1rem;
   background-color: var(--chip-radio-background);
@@ -123,6 +130,10 @@
 .label {
   position: relative;
   top: -0.0625rem;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .icon svg {

--- a/src/components/chip/stories/chip-group.stories.js
+++ b/src/components/chip/stories/chip-group.stories.js
@@ -32,7 +32,11 @@ export default {
   },
 }
 
-const chips = ["Chip 1", "Chip 2", "Chip 3"]
+const chips = [
+  "Chip mit einem sehr langen Text der dann hoffentlich mal abgeschnitten wird",
+  "Chip 2",
+  "Chip 3",
+]
 
 function invertedBackground(args, content) {
   return html`

--- a/src/components/chip/stories/chip-group.stories.js
+++ b/src/components/chip/stories/chip-group.stories.js
@@ -1,8 +1,10 @@
 import { html } from "lit"
 import { ifDefined } from "lit/directives/if-defined.js"
+import { styleMap } from "lit/directives/style-map.js"
 
 import "../leu-chip-selectable.js"
 import "../leu-chip-removable.js"
+import "../leu-chip-link.js"
 import "../leu-chip-group.js"
 
 import { SELECTION_MODES } from "../ChipGroup.js"
@@ -20,7 +22,9 @@ export default {
       control: "select",
       options: [1, 2, 3, 4, 5, 6],
     },
-    inverted: { control: "boolean" },
+    "--leu-chip-group-gap": {
+      control: "text",
+    },
   },
   args: {
     selectionMode: "",
@@ -68,8 +72,13 @@ function invertedBackground({ args, content }) {
 }
 
 function chipGroup({ args, content }) {
+  const styles = {
+    "--leu-chip-group-gap": args["--leu-chip-group-gap"],
+  }
+
   const nextContent = html`
     <leu-chip-group
+      style=${styleMap(styles)}
       selection-mode=${ifDefined(args.selectionMode)}
       heading-level=${ifDefined(args.headingLevel)}
       label=${ifDefined(args.label)}

--- a/src/components/chip/stories/chip-group.stories.js
+++ b/src/components/chip/stories/chip-group.stories.js
@@ -1,4 +1,5 @@
 import { html } from "lit"
+import { ifDefined } from "lit/directives/if-defined.js"
 
 import "../leu-chip-selectable.js"
 import "../leu-chip-removable.js"
@@ -14,6 +15,10 @@ export default {
     selectionMode: {
       control: "select",
       options: Object.values(SELECTION_MODES),
+    },
+    headingLevel: {
+      control: "select",
+      options: [1, 2, 3, 4, 5, 6],
     },
     inverted: { control: "boolean" },
   },
@@ -38,71 +43,104 @@ const chips = [
   "Chip 3",
 ]
 
-function invertedBackground(args, content) {
-  return html`
-    <div
-      style="background: ${args.inverted
-        ? "hsla(209, 83%, 59%, 1)"
-        : "var(--leu-color-black-5)"}; padding: 1rem;"
-      data-root
+const links = [
+  "Steuererklärung",
+  "Abstimmungen",
+  "Zentrale Aufnahmeprüfung",
+  "Pass & Identitätskarte",
+  "Arbeiten beim Kanton",
+]
+
+function invertedBackground({ args, content }) {
+  return {
+    content: html`
+      <div
+        style="background: ${args.inverted
+          ? "hsla(209, 83%, 59%, 1)"
+          : "var(--leu-color-black-5)"}; padding: 1rem;"
+        data-root
+      >
+        ${content}
+      </div>
+    `,
+    args,
+  }
+}
+
+function chipGroup({ args, content }) {
+  const nextContent = html`
+    <leu-chip-group
+      selection-mode=${ifDefined(args.selectionMode)}
+      heading-level=${ifDefined(args.headingLevel)}
+      label=${ifDefined(args.label)}
+      ?inverted=${args.inverted}
     >
       ${content}
-    </div>
+    </leu-chip-group>
   `
+
+  return { args, content: nextContent }
 }
 
 function DefaultTemplate(args) {
   const content = html`
-    <leu-chip-group selection-mode=${args.selectionMode}>
-      ${chips.map(
-        (chip) => html`
-          <leu-chip-removable ?inverted=${args.inverted} label=${chip}>
-          </leu-chip-removable>
-        `
-      )}
-    </leu-chip-group>
+    ${chips.map(
+      (chip) => html`
+        <leu-chip-removable ?inverted=${args.inverted} label=${chip}>
+        </leu-chip-removable>
+      `
+    )}
   `
 
-  return invertedBackground(args, content)
+  return invertedBackground(chipGroup({ args, content })).content
 }
 
 function SingleTemplate(args) {
   const content = html`
-    <leu-chip-group selection-mode=${args.selectionMode}>
-      ${chips.map(
-        (chip) => html`
-          <leu-chip-selectable
-            ?inverted=${args.inverted}
-            variant=${SELECTABLE_VARIANTS.radio}
-            value="chip-${chip}"
-            label=${chip}
-          >
-          </leu-chip-selectable>
-        `
-      )}
-    </leu-chip-group>
+    ${chips.map(
+      (chip) => html`
+        <leu-chip-selectable
+          ?inverted=${args.inverted}
+          variant=${SELECTABLE_VARIANTS.radio}
+          value="chip-${chip}"
+          label=${chip}
+        >
+        </leu-chip-selectable>
+      `
+    )}
   `
 
-  return invertedBackground(args, content)
+  return invertedBackground(chipGroup({ args, content })).content
 }
 
 function MultipleTemplate(args) {
   const content = html`
-    <leu-chip-group selection-mode=${args.selectionMode}>
-      ${chips.map(
-        (chip) => html`
-          <leu-chip-selectable
-            ?inverted=${args.inverted}
-            value="chip-${chip}"
-            label=${chip}
-          >
-          </leu-chip-selectable>
-        `
-      )}
-    </leu-chip-group>
+    ${chips.map(
+      (chip) => html`
+        <leu-chip-selectable
+          ?inverted=${args.inverted}
+          value="chip-${chip}"
+          label=${chip}
+        >
+        </leu-chip-selectable>
+      `
+    )}
   `
 
-  return invertedBackground(args, content)
+  return invertedBackground(chipGroup({ args, content })).content
+}
+
+function LabeledTemplate(args) {
+  const content = html`
+    ${links.map(
+      (chip) => html`
+        <leu-chip-link ?inverted=${args.inverted} label=${chip}>
+        </leu-chip-link>
+      `
+    )}
+  `
+
+  return invertedBackground(chipGroup({ args, content })).content
 }
 
 export const Default = DefaultTemplate.bind({})
@@ -113,3 +151,6 @@ Single.args = { selectionMode: SELECTION_MODES.single }
 
 export const Multiple = MultipleTemplate.bind({})
 Multiple.args = { selectionMode: SELECTION_MODES.multiple }
+
+export const Labeled = LabeledTemplate.bind({})
+Labeled.args = { label: "Top Themen" }


### PR DESCRIPTION
- Avoid text from wrapping inside a chip element
- Add optional label to the chip group
- Use a custom property to define the gap between chips inside a chip group. The design system contains a few different gap settings that can't be determined in a sensible implicit way by the chip group component. Now it is a concern of the library user to set correct value based on the context it used in. 