### PR TITLE
Button: Place Icons with Slots

### DIFF
--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -56,6 +56,9 @@ const ARIA_ROLES_SELECTED = [
 
 /**
  * @tagname leu-button
+ * @slot before - The icon to display before the label
+ * @slot after - The icon to display after the label
+ * @slot - The label of the button or the icon if no label is set
  */
 export class LeuButton extends LitElement {
   static styles = styles

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -63,6 +63,8 @@ button.small {
   padding: 6px 24px;
   font-size: 14px;
   line-height: 20px;
+
+  --leu-icon-size: 1rem;
 }
 
 button.small.icon-only {
@@ -121,6 +123,8 @@ button.secondary:disabled {
 
 /* ghost */
 button.ghost {
+  --leu-icon-size: 1rem;
+
   background: transparent;
   padding: 0 0.5rem;
   color: var(--leu-color-black-60);

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -17,15 +17,11 @@ button {
   column-gap: 8px;
 }
 
-.label {
+.content {
   flex: 1 1 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.icon .label {
-  display: none;
 }
 
 button.round {
@@ -58,7 +54,7 @@ button.regular {
   line-height: 24px;
 }
 
-button.regular.icon {
+button.regular.icon-only {
   padding: 12px;
 }
 
@@ -69,7 +65,7 @@ button.small {
   line-height: 20px;
 }
 
-button.small.icon {
+button.small.icon-only {
   padding: 8px;
 }
 
@@ -207,7 +203,9 @@ button.ghost.inverted:disabled {
   display: block;
 }
 
-.ghost :is(.icon-wrapper--before, .icon-wrapper--after) {
+.ghost.icon-before .icon-wrapper--before,
+.ghost.icon-after .icon-wrapper--after {
+  display: block;
   padding: 0.5rem;
   border-radius: 50%;
   background: var(--leu-color-black-transp-10);

--- a/src/components/button/stories/button.stories.js
+++ b/src/components/button/stories/button.stories.js
@@ -1,7 +1,8 @@
-import { html } from "lit"
+import { html, nothing } from "lit"
 import { ifDefined } from "lit/directives/if-defined.js"
 import { classMap } from "lit/directives/class-map.js"
 import "../leu-button.js"
+import "../../icon/leu-icon.js"
 import { paths as iconPaths } from "../../icon/paths.js"
 import {
   BUTTON_VARIANTS,
@@ -35,8 +36,6 @@ function Template(args = {}) {
         content=${ifDefined(args.content)}
         size=${ifDefined(args.size)}
         variant=${ifDefined(args.variant)}
-        icon=${ifDefined(args.icon)}
-        iconPosition=${ifDefined(args.iconPosition)}
         type=${ifDefined(args.type)}
         expanded=${ifDefined(args.expanded)}
         ?round=${args.round}
@@ -45,6 +44,12 @@ function Template(args = {}) {
         ?disabled=${args.disabled}
         @click=${copyContent}
       >
+        ${args.icon
+          ? html`<leu-icon
+              slot=${args.iconPosition}
+              name=${args.icon}
+            ></leu-icon>`
+          : nothing}
         ${args.content}
       </leu-button>
     </div>
@@ -70,13 +75,18 @@ function Template(args = {}) {
 
 export const Regular = Template.bind({})
 Regular.argTypes = {
-  content: { type: "string" },
+  content: { control: "text" },
   icon: { control: "select", options: Object.keys(iconPaths) },
-  iconPosition: { control: "select", options: ["before", "after"] },
+  iconPosition: {
+    control: "select",
+    options: ["before", "after"],
+  },
   type: { control: "radio", options: BUTTON_TYPES },
   size: { control: "radio", options: BUTTON_SIZES },
   variant: { control: "radio", options: BUTTON_VARIANTS },
   expanded: { control: "radio", options: BUTTON_EXPANDED_OPTIONS },
+  disabled: { control: "boolean" },
+  round: { control: "boolean" },
 }
 Regular.args = {
   content: "Click Mich...",
@@ -86,7 +96,7 @@ Regular.args = {
   inverted: false,
 
   icon: null,
-  iconPosition: null,
+  iconPosition: "before",
   size: null,
   variant: null,
   type: null,
@@ -97,9 +107,14 @@ const items = [
   { content: "Active", active: true },
   { content: "Disabled", disabled: true },
 
-  { content: "Normal", icon: "calendar" },
-  { content: "Active", icon: "calendar", active: true },
-  { content: "Disabled", icon: "calendar", disabled: true },
+  { content: "Normal", icon: "calendar", iconPosition: "before" },
+  { content: "Active", icon: "calendar", iconPosition: "before", active: true },
+  {
+    content: "Disabled",
+    icon: "calendar",
+    iconPosition: "before",
+    disabled: true,
+  },
 
   { content: "Normal", icon: "calendar", iconPosition: "after" },
   { content: "Active", icon: "calendar", iconPosition: "after", active: true },
@@ -120,13 +135,35 @@ const items = [
 ]
 
 const ghostItems = [
-  { content: "Normal", icon: "calendar" },
-  { content: "Active", icon: "calendar", active: true },
-  { content: "Disabled", icon: "calendar", disabled: true },
+  { content: "Normal", icon: "calendar", iconPosition: "before" },
+  { content: "Active", icon: "calendar", iconPosition: "before", active: true },
+  {
+    content: "Disabled",
+    icon: "calendar",
+    iconPosition: "before",
+    disabled: true,
+  },
 
-  { content: "Normal", icon: "calendar", expanded: "closed" },
-  { content: "Active", icon: "calendar", active: true, expanded: "closed" },
-  { content: "Disabled", icon: "calendar", disabled: true, expanded: "closed" },
+  {
+    content: "Normal",
+    icon: "calendar",
+    iconPosition: "before",
+    expanded: "closed",
+  },
+  {
+    content: "Active",
+    icon: "calendar",
+    iconPosition: "before",
+    active: true,
+    expanded: "closed",
+  },
+  {
+    content: "Disabled",
+    icon: "calendar",
+    iconPosition: "before",
+    disabled: true,
+    expanded: "closed",
+  },
 
   { content: "Normal", icon: "calendar", iconPosition: "after" },
   { content: "Active", icon: "calendar", iconPosition: "after", active: true },
@@ -269,8 +306,6 @@ function TemplateOverview() {
                             label=${ifDefined(item.label)}
                             size=${ifDefined(size.size)}
                             variant=${ifDefined(group.variant)}
-                            icon=${ifDefined(item.icon)}
-                            iconPosition=${ifDefined(item.iconPosition)}
                             expanded=${ifDefined(item.expanded)}
                             ?round=${item.round}
                             ?active=${item.active}
@@ -278,6 +313,12 @@ function TemplateOverview() {
                             ?inverted=${group.inverted}
                             @click=${copyContent}
                           >
+                            ${item.icon
+                              ? html` <leu-icon
+                                  slot=${ifDefined(item.iconPosition)}
+                                  name=${item.icon}
+                                ></leu-icon>`
+                              : nothing}
                             ${item.content}
                           </leu-button>
                         `

--- a/src/components/button/stories/button.stories.js
+++ b/src/components/button/stories/button.stories.js
@@ -46,7 +46,7 @@ function Template(args = {}) {
       >
         ${args.icon
           ? html`<leu-icon
-              slot=${args.iconPosition}
+              slot=${ifDefined(args.content ? args.iconPosition : undefined)}
               name=${args.icon}
             ></leu-icon>`
           : nothing}

--- a/src/components/button/test/button.test.js
+++ b/src/components/button/test/button.test.js
@@ -2,6 +2,7 @@ import { html } from "lit"
 import { fixture, expect, elementUpdated, oneEvent } from "@open-wc/testing"
 
 import "../leu-button.js"
+import "../../icon/leu-icon.js"
 
 async function defaultFixture() {
   return fixture(html` <leu-button>button</leu-button>`)
@@ -22,7 +23,9 @@ describe("LeuButton", () => {
 
   it("passes the a11y audit with no visible text", async () => {
     const el = await fixture(
-      html` <leu-button icon="download" label="sichern"></leu-button>`
+      html` <leu-button label="sichern">
+        <leu-icon name="download"></leu-icon>
+      </leu-button>`
     )
 
     await expect(el).shadowDom.to.be.accessible()
@@ -36,9 +39,8 @@ describe("LeuButton", () => {
 
   it("sets the aria-label attribute", async () => {
     const el = await fixture(
-      html` <leu-button
-        icon="download"
-        label="Dokument herunterladen"
+      html` <leu-button label="Dokument herunterladen"
+        ><leu-icon name="download"></leu-icon
       ></leu-button>`
     )
     const button = el.shadowRoot.querySelector("button")
@@ -46,62 +48,33 @@ describe("LeuButton", () => {
     expect(button).to.have.attribute("aria-label", "Dokument herunterladen")
   })
 
-  it("renders the icon at the correct position", async () => {
+  it("renders the icon slots at the correct position", async () => {
     const el = await fixture(
-      html` <leu-button icon="addNew">Sichern</leu-button>`
-    )
-
-    const button = el.shadowRoot.querySelector("button")
-
-    expect(button).dom.to.equal(
-      "<button><div><svg><path /></svg></div><slot></slot></div>",
-      { ignoreAttributes: ["d", "class", "type"] }
-    )
-
-    el.iconPosition = "after"
-
-    await elementUpdated(el)
-
-    expect(button).dom.to.equal(
-      "<button><slot></slot><div><svg><path /></svg></div></div>",
-      { ignoreAttributes: ["d", "class", "type"] }
-    )
-  })
-
-  it("renders the icon at the correct size", async () => {
-    const el = await fixture(
-      html` <leu-button icon="addNew">Sichern</leu-button>`
-    )
-
-    const button = el.shadowRoot.querySelector("button")
-
-    expect(button).dom.to.equal(
-      "<button><div><svg width='24' height='24'><path /></svg></div><slot></slot></div>",
-      { ignoreAttributes: ["d", "class", "type"] }
-    )
-
-    el.size = "small"
-
-    await elementUpdated(el)
-
-    expect(button).dom.to.equal(
-      "<button><div><svg width='16' height='16'><path /></svg></div><slot></slot></div>",
-      { ignoreAttributes: ["d", "class", "type"] }
-    )
-  })
-
-  it("renders the expanded icon only when the variant is ghost", async () => {
-    const el = await fixture(
-      html` <leu-button icon="addNew" variant="ghost" expanded="true"
-        >Sichern</leu-button
+      html` <leu-button
+        ><leu-icon name="addBew" slot="before"></leu-icon>Sichern</leu-button
       >`
     )
 
     const button = el.shadowRoot.querySelector("button")
 
     expect(button).dom.to.equal(
-      "<button class='ghost regular'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot><div class='icon-wrapper icon-wrapper--expanded'><svg width='24' height='24'><path /></svg></div></div>",
-      { ignoreAttributes: ["d", "type", "width", "height"] }
+      "<button><slot name='before'></slot><span><slot></slot></span><slot name='after'></slot></button>",
+      { ignoreAttributes: ["class", "type"] }
+    )
+  })
+
+  it("renders the expanded icon only when the variant is ghost", async () => {
+    const el = await fixture(
+      html` <leu-button variant="ghost" expanded="true"
+        ><leu-icon name="addNew" slot="before"></leu-icon>Sichern</leu-button
+      >`
+    )
+
+    const button = el.shadowRoot.querySelector("button")
+
+    expect(button).dom.to.equal(
+      "<button><slot name='before'></slot><span><slot></slot></span><slot name='after'></slot><div class='icon-wrapper icon-wrapper--expanded'><leu-icon name='angleDropDown' size='24'></leu-icon></div></button>",
+      { ignoreAttributes: ["class", "type"] }
     )
 
     el.variant = "primary"
@@ -109,20 +82,17 @@ describe("LeuButton", () => {
     await elementUpdated(el)
 
     expect(button).dom.to.equal(
-      "<button class='primary regular'><div class='icon-wrapper icon-wrapper--before'><svg width='24' height='24'><path /></svg></div><slot></slot></div>",
-      { ignoreAttributes: ["d", "type"] }
+      "<button class='primary regular'><slot name='before'></slot><span><slot></slot></span><slot name='after'></slot></button>",
+      { ignoreAttributes: ["class", "type"] }
     )
   })
 
   it("sets the dissabled attrbiute", async () => {
     const el = await fixture(
-      html` <leu-button
-        icon="addNew"
-        label="Sichern"
-        variant="ghost"
-        expanded="true"
-        disabled
-      ></leu-button>`
+      html` <leu-button variant="ghost" expanded="true" disabled>
+        <leu-icon name="addNew" slot="before"></leu-icon>
+        Sichern
+      </leu-button>`
     )
 
     const button = el.shadowRoot.querySelector("button")
@@ -137,11 +107,8 @@ describe("LeuButton", () => {
 
   it("reflects the role attribute", async () => {
     const el = await fixture(
-      html` <leu-button
-        icon="addNew"
-        variant="ghost"
-        componentRole="menuitemradio"
-        >Sichern</leu-button
+      html` <leu-button variant="ghost" componentRole="menuitemradio"
+        ><leu-icon name="addNew" slot="before"></leu-icon>Sichern</leu-button
       >`
     )
 
@@ -152,12 +119,8 @@ describe("LeuButton", () => {
 
   it("sets the either checked or selected attribute depending on the role", async () => {
     const el = await fixture(
-      html` <leu-button
-        icon="addNew"
-        variant="ghost"
-        componentRole="menuitemradio"
-        active
-        >Sichern</leu-button
+      html` <leu-button variant="ghost" componentRole="menuitemradio" active
+        ><leu-icon name="addNew" slot="before"></leu-icon>Sichern</leu-button
       >`
     )
 

--- a/src/components/chip/ChipRemovable.js
+++ b/src/components/chip/ChipRemovable.js
@@ -24,7 +24,7 @@ export class LeuChipRemovable extends LeuChipBase {
   render() {
     return html`<button @click=${(e) => this.handleClick(e)} class="button">
       <span class="label">${this.label}</span>
-      <leu-icon name="close" size="16" class="icon"></leu-icon>
+      <leu-icon name="close" class="icon"></leu-icon>
     </button>`
   }
 }

--- a/src/components/chip/chip.css
+++ b/src/components/chip/chip.css
@@ -28,6 +28,8 @@
   --chip-radio-border: var(--chip-radio-border-default);
   --chip-radio-background: var(--chip-radio-background-default);
 
+  --leu-icon-size: 1rem;
+
   font-family: var(--chip-font-regular);
 
   /* Allow shrinking to achieve text truncation (ellipsis) */

--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -86,14 +86,15 @@ export class LeuDropdown extends LitElement {
         <leu-button
           class="button"
           slot="anchor"
-          icon="download"
           variant="ghost"
           expanded=${this.expanded ? "true" : "false"}
           aria-expanded=${this.expanded ? "true" : "false"}
           aria-controls="content"
           ?active=${this.expanded}
           @click=${this._handleToggleClick}
-          >${this.label}</leu-button
+        >
+          <leu-icon name="download" slot="before"></leu-icon>${this
+            .label}</leu-button
         >
         <div id="content" class="content" ?hidden=${!this.expanded}>
           <slot @slotchange=${this._handleSlotChange}></slot>

--- a/src/components/icon/Icon.js
+++ b/src/components/icon/Icon.js
@@ -9,14 +9,13 @@ import { paths } from "./paths.js"
  *
  * @tagname leu-icon
  * @prop {import("./paths").IconPathName} name - The name of the icon to display.
- * @prop {number} size - Width and height of the icon. A icon will always be displayed as a square.
+ * @cssprop --leu-icon-size - The size of the icon.
  */
 export class LeuIcon extends LitElement {
   static styles = styles
 
   static properties = {
     name: { type: String, reflect: true },
-    size: { type: Number, reflect: true },
   }
 
   constructor() {
@@ -26,7 +25,6 @@ export class LeuIcon extends LitElement {
      * @type {import("./paths").IconPathName}
      */
     this.name = "addNew"
-    this.size = 24
   }
 
   render() {
@@ -34,8 +32,8 @@ export class LeuIcon extends LitElement {
 
     return html`
       <svg
-        width="${this.size}"
-        height="${this.size}"
+        width="24"
+        height="24"
         fill="currentColor"
         viewBox="0 0 24 24"
         fill-rule="evenodd"

--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -1,3 +1,5 @@
 svg {
   display: block;
+  width: var(--leu-icon-size, 1.5rem);
+  height: var(--leu-icon-size, 1.5rem);
 }

--- a/src/components/icon/stories/icon.stories.js
+++ b/src/components/icon/stories/icon.stories.js
@@ -22,9 +22,8 @@ export default {
 
 function Template({ name, size, color }) {
   return html` <leu-icon
-    style="color: ${color}"
+    style="color: ${color}; ${size ? `--leu-icon-size: ${size}px` : ""};"
     name=${ifDefined(name)}
-    size=${ifDefined(size)}
   ></leu-icon>`
 }
 

--- a/src/components/icon/test/icon.test.js
+++ b/src/components/icon/test/icon.test.js
@@ -1,5 +1,5 @@
 import { html } from "lit"
-import { fixture, expect, elementUpdated } from "@open-wc/testing"
+import { fixture, expect } from "@open-wc/testing"
 
 import "../leu-icon.js"
 
@@ -29,32 +29,10 @@ describe("LeuIcon", () => {
     expect(svg).to.have.attribute("height", "24")
   })
 
-  it("renders a small icon", async () => {
-    const el = await fixture(html` <leu-icon size="16"></leu-icon> `)
-
-    const svg = el.shadowRoot.querySelector("svg")
-
-    expect(svg).to.have.attribute("width", "16")
-    expect(svg).to.have.attribute("height", "16")
-  })
-
   it("renders the correct icon path", async () => {
     const el = await fixture(html` <leu-icon name="angleDropup"></leu-icon> `)
 
     const path = el.shadowRoot.querySelector("path")
     expect(path).to.have.attribute("d", "M7 14.5L12 9.5L17 14.5H7Z")
-  })
-
-  it("doesn't reflect the size value to the viewBox attribute", async () => {
-    const el = await defaultFixture()
-
-    const svg = el.shadowRoot.querySelector("svg")
-
-    expect(svg).to.have.attribute("viewBox", "0 0 24 24")
-
-    el.size = 16
-    await elementUpdated(el)
-
-    expect(svg).to.have.attribute("viewBox", "0 0 24 24")
   })
 })

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -2,6 +2,7 @@ import { html, LitElement } from "lit"
 import { live } from "lit/directives/live.js"
 
 import "../button/leu-button.js"
+import "../icon/leu-icon.js"
 import styles from "./pagination.css"
 
 import "../visually-hidden/leu-visually-hidden.js"
@@ -148,22 +149,22 @@ export class LeuPagination extends LitElement {
       <div class="label">von ${this._maxPage}</div>
       <div class="button-group">
         <leu-button
-          icon="angleLeft"
           variant="secondary"
           label="Vorherige Seite"
           @click=${(_) => {
             this._updatePage(this.page - 1)
           }}
           ?disabled=${this._isFirstPage()}
+          ><leu-icon name="angleLeft"></leu-icon
         ></leu-button>
         <leu-button
-          icon="angleRight"
           variant="secondary"
           label="Nächste Seite"
           @click=${(_) => {
             this._updatePage(this.page + 1)
           }}
           ?disabled=${this._isLastPage()}
+          ><leu-icon name="angleRight"></leu-icon
         ></leu-button>
       </div>
     `

--- a/src/components/scroll-top/ScrollTop.js
+++ b/src/components/scroll-top/ScrollTop.js
@@ -3,6 +3,7 @@ import { classMap } from "lit/directives/class-map.js"
 
 import styles from "./scroll-top.css"
 import "../button/leu-button.js"
+import "../icon/leu-icon.js"
 import { throttle } from "../../lib/utils.js"
 
 /**
@@ -75,11 +76,11 @@ export class LeuScrollTop extends LitElement {
     return html`
       <div class=${classMap(cssClasses)}>
         <leu-button
-          icon="arrowUp"
           label="Zum Seitenanfang"
           round
           @click="${() => LeuScrollTop.scrollToTop()}"
         >
+          <leu-icon name="arrowUp"></leu-icon>
         </leu-button>
       </div>
     `

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -115,7 +115,6 @@ export class LeuTable extends LitElement {
   sortArrowIcon() {
     return html`<leu-icon
       name=${this.sortOrderAsc ? "arrowDown" : "arrowUp"}
-      size="20"
     ></leu-icon>`
   }
 

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -74,6 +74,8 @@ button {
 }
 
 thead leu-icon {
+  --leu-icon-size: 1.25rem;
+
   display: inline-block;
   color: var(--leu-color-accent-blue);
   padding: 0;


### PR DESCRIPTION
Use Slots to display icons inside a button.
Remove the `size` attribute from the Icon. The size can now be set with a css custom property.