### PR TITLE
fix(popup): define a z-index value for the popup content

### DIFF
--- a/src/components/popup/popup.css
+++ b/src/components/popup/popup.css
@@ -19,6 +19,7 @@
   position: absolute;
   top: 0;
   left: 0;
+  z-index: var(--leu-z-index-popup);
 }
 
 /* TODO: Should visibility be a matter of the popup component? */

--- a/src/styles/custom-properties.css
+++ b/src/styles/custom-properties.css
@@ -51,5 +51,7 @@
   --leu-box-shadow-regular: 0px 0px 16px var(--leu-color-black-transp-20);
   --leu-box-shadow-long: 0px 0px 80px var(--leu-color-black-transp-20);
 
+  --leu-z-index-popup: 100;
+
   @leu-font-styles './font-definitions.json';
 }


### PR DESCRIPTION
Use global z-index values for proper overlapping of components.

Those values can also be overridden to match the environment they're used in.