### PR TITLE
menu: roving tab index

### DIFF
--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -4,6 +4,7 @@ import { ifDefined } from "lit/directives/if-defined.js"
 
 import "../icon/leu-icon.js"
 import { HasSlotController } from "../../lib/hasSlotController.js"
+import { ARIA_CHECKED_ROLES, ARIA_SELECTED_ROLES } from "../../lib/a11y.js"
 
 import styles from "./button.css"
 
@@ -26,33 +27,6 @@ export { BUTTON_TYPES }
 
 export const BUTTON_EXPANDED_OPTIONS = ["true", "false"]
 Object.freeze(BUTTON_EXPANDED_OPTIONS)
-
-/**
- * All roles that are associated with a aria-checked attribute
- * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked
- */
-const ARIA_ROLES_CHECKED = [
-  "checkbox",
-  "menuitemcheckbox",
-  "menuitemradio",
-  "option",
-  "radio",
-  "switch",
-]
-
-/**
- * All roles that are associated with a aria-selected attribute
- * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected
- */
-const ARIA_ROLES_SELECTED = [
-  "gridcell",
-  "option",
-  "row",
-  "tab",
-  "columnheader",
-  "rowheader",
-  "treeitem",
-]
 
 /**
  * @tagname leu-button
@@ -142,9 +116,9 @@ export class LeuButton extends LitElement {
     }
 
     if (this.componentRole) {
-      if (ARIA_ROLES_CHECKED.includes(this.componentRole)) {
+      if (ARIA_CHECKED_ROLES.includes(this.componentRole)) {
         attributes.checked = this.active ? "true" : "false"
-      } else if (ARIA_ROLES_SELECTED.includes(this.componentRole)) {
+      } else if (ARIA_SELECTED_ROLES.includes(this.componentRole)) {
         attributes.selected = this.active ? "true" : "false"
       }
     }

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -181,6 +181,7 @@ export class LeuButton extends LitElement {
         aria-label=${ifDefined(aria.label)}
         aria-selected=${ifDefined(aria.selected)}
         aria-checked=${ifDefined(aria.checked)}
+        aria-expanded=${ifDefined(this.expanded)}
         role=${ifDefined(aria.role)}
         class=${classMap(cssClasses)}
         ?disabled=${this.disabled}

--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -129,8 +129,6 @@ export class LeuDropdown extends LitElement {
           slot="anchor"
           variant="ghost"
           expanded=${this.expanded ? "true" : "false"}
-          aria-expanded=${this.expanded ? "true" : "false"}
-          aria-controls="content"
           ?active=${this.expanded}
           @click=${this._handleToggleClick}
           @keyup=${this._keyUpToggleHandler}

--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -24,7 +24,6 @@ export class LeuDropdown extends LitElement {
 
     this.label = ""
     this.expanded = false
-    this.menuItems = []
 
     /** @type {import("lit/directives/ref").Ref<HTMLButtonElement>} */
     this._toggleRef = createRef()
@@ -35,20 +34,21 @@ export class LeuDropdown extends LitElement {
     this.addEventListener("keyup", this._keyUpHandler)
     document.addEventListener("click", this._documentClickHandler)
 
-    this._getMenu().addEventListener("keydown", (e) => {
-      if (e.key === "Escape" || e.key === "Tab") {
-        e.preventDefault()
-        this.expanded = false
-        this._toggleRef.value.focus()
-      }
-    })
+    const menu = this._getMenu()
+
+    menu.addEventListener("keydown", this._keyDownMenuHandler)
+    menu.addEventListener("click", this._menuItemClickHandler)
   }
 
   disconnectedCallback() {
     super.disconnectedCallback()
-    this._removeMenuItemListeners()
     this.removeEventListener("keyup", this._keyUpHandler)
     document.removeEventListener("click", this._documentClickHandler)
+
+    const menu = this._getMenu()
+
+    menu.removeEventListener("keydown", this._keyDownMenuHandler)
+    menu.removeEventListener("click", this._menuItemClickHandler)
   }
 
   _documentClickHandler = (event) => {
@@ -66,7 +66,7 @@ export class LeuDropdown extends LitElement {
   async _keyUpToggleHandler(event) {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
       const menu = this._getMenu()
-      const menuItems = menu._getMenuItems()
+      const menuItems = menu.getMenuItems()
 
       this.expanded = true
 
@@ -82,24 +82,24 @@ export class LeuDropdown extends LitElement {
     }
   }
 
-  _handleSlotChange() {
-    this._removeMenuItemListeners()
-    this.menuItems = [...this.querySelectorAll("leu-menu > leu-menu-item")]
-
-    this.menuItems.forEach((item) =>
-      item.addEventListener("click", this._handleMenuItemClick)
-    )
+  _menuItemClickHandler = (e) => {
+    if (e.target.tagName.toLowerCase() === "leu-menu-item") {
+      this.expanded = false
+      this._toggleRef.value.focus()
+    }
   }
 
-  _removeMenuItemListeners() {
-    this.menuItems.forEach((item) => {
-      item.removeEventListener("click", this._handleMenuItemClick)
-    })
-  }
-
-  _handleMenuItemClick = () => {
-    this.expanded = false
-    this._toggleRef.value.focus()
+  /**
+   * Close the dropdown when the user presses the Escape or the Tab key.
+   * Navigating the menu with the arrow keys is handled by the menu itself.
+   * @param {KeyboardEvent} e
+   */
+  _keyDownMenuHandler = (e) => {
+    if (e.key === "Escape" || e.key === "Tab") {
+      e.preventDefault()
+      this.expanded = false
+      this._toggleRef.value.focus()
+    }
   }
 
   _handleToggleClick() {

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -2,10 +2,25 @@ import { html, LitElement } from "lit"
 import styles from "./menu.css"
 
 /**
+ * @typedef {'single' | 'multiple' | 'none'} SelectsType
+ */
+
+/**
  * @tagname leu-menu
  */
 export class LeuMenu extends LitElement {
   static styles = styles
+
+  static properties = {
+    selects: { type: String, reflect: true },
+  }
+
+  constructor() {
+    super()
+
+    /** @type {SelectsType} */
+    this.selects = "none"
+  }
 
   connectedCallback() {
     super.connectedCallback()
@@ -13,8 +28,6 @@ export class LeuMenu extends LitElement {
     if (!this.getAttribute("role")) {
       this.setAttribute("role", "menu")
     }
-
-    this.setAttribute("aria-orientation", "vertical")
 
     this.addEventListener("keydown", this._handleKeyDown)
   }
@@ -26,6 +39,30 @@ export class LeuMenu extends LitElement {
 
   _handleSlotChange() {
     this.setCurrentItem(0)
+    this._setMenuItemRoles()
+  }
+
+  _setMenuItemRoles() {
+    const menuRole = this.getAttribute("role")
+    let menuItemRole
+
+    if (menuRole === "menu") {
+      if (this.selects === "multiple") {
+        menuItemRole = "menuitemcheckbox"
+      } else if (this.selects === "single") {
+        menuItemRole = "menuitemradio"
+      } else {
+        menuItemRole = "menuitem"
+      }
+    } else if (menuRole === "listbox") {
+      menuItemRole = "option"
+    }
+
+    if (menuItemRole) {
+      this.getMenuItems().forEach((menuItem) => {
+        menuItem.componentRole = menuItemRole // eslint-disable-line no-param-reassign
+      })
+    }
   }
 
   /**
@@ -67,6 +104,12 @@ export class LeuMenu extends LitElement {
     this.getMenuItems().forEach((menuItem, i) => {
       menuItem.tabIndex = i === index ? 0 : -1 // eslint-disable-line no-param-reassign
     })
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has("selects")) {
+      this._setMenuItemRoles()
+    }
   }
 
   render() {

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -7,6 +7,67 @@ import styles from "./menu.css"
 export class LeuMenu extends LitElement {
   static styles = styles
 
+  connectedCallback() {
+    super.connectedCallback()
+
+    this.setAttribute("role", "menu")
+    this.setAttribute("aria-orientation", "vertical")
+
+    this.addEventListener("keydown", this._handleKeyDown)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+    this.removeEventListener("keydown", this._handleKeyDown)
+  }
+
+  _handleSlotChange() {
+    this.setCurrentItem(0)
+  }
+
+  /**
+   *
+   * @returns {import("./MenuItem").LeuMenuItem[]}
+   */
+  _getMenuItems() {
+    const slot = this.shadowRoot.querySelector("slot")
+    return slot
+      .assignedElements({ flatten: true })
+      .filter(
+        (el) => el.tagName.toLowerCase() === "leu-menu-item" && !el.disabled
+      )
+  }
+
+  _handleKeyDown(event) {
+    if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      const menuItems = this._getMenuItems()
+      let index = menuItems.findIndex((menuItem) => menuItem.tabIndex === 0)
+
+      if (event.key === "ArrowDown") {
+        index += 1
+      } else if (event.key === "ArrowUp") {
+        index -= 1
+      } else if (event.key === "Home") {
+        index = 0
+      } else if (event.key === "End") {
+        index = menuItems.length - 1
+      }
+
+      // When the index is out of bounds, it will wrap around to allow
+      // circular navigation
+      index = (index + menuItems.length) % menuItems.length
+
+      this.setCurrentItem(index)
+      menuItems[index].focus()
+    }
+  }
+
+  setCurrentItem(index) {
+    this._getMenuItems().forEach((menuItem, i) => {
+      menuItem.tabIndex = i === index ? 0 : -1 // eslint-disable-line no-param-reassign
+    })
+  }
+
   render() {
     return html`<slot></slot>`
   }

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -10,7 +10,10 @@ export class LeuMenu extends LitElement {
   connectedCallback() {
     super.connectedCallback()
 
-    this.setAttribute("role", "menu")
+    if (!this.getAttribute("role")) {
+      this.setAttribute("role", "menu")
+    }
+
     this.setAttribute("aria-orientation", "vertical")
 
     this.addEventListener("keydown", this._handleKeyDown)

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -33,9 +33,7 @@ export class LeuMenu extends LitElement {
     const slot = this.shadowRoot.querySelector("slot")
     return slot
       .assignedElements({ flatten: true })
-      .filter(
-        (el) => el.tagName.toLowerCase() === "leu-menu-item" && !el.disabled
-      )
+      .filter((el) => el.tagName.toLowerCase() === "leu-menu-item")
   }
 
   _handleKeyDown(event) {

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -29,7 +29,7 @@ export class LeuMenu extends LitElement {
    *
    * @returns {import("./MenuItem").LeuMenuItem[]}
    */
-  _getMenuItems() {
+  getMenuItems() {
     const slot = this.shadowRoot.querySelector("slot")
     return slot
       .assignedElements({ flatten: true })
@@ -38,7 +38,7 @@ export class LeuMenu extends LitElement {
 
   _handleKeyDown(event) {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
-      const menuItems = this._getMenuItems()
+      const menuItems = this.getMenuItems()
       let index = menuItems.findIndex((menuItem) => menuItem.tabIndex === 0)
 
       if (event.key === "ArrowDown") {
@@ -61,7 +61,7 @@ export class LeuMenu extends LitElement {
   }
 
   setCurrentItem(index) {
-    this._getMenuItems().forEach((menuItem, i) => {
+    this.getMenuItems().forEach((menuItem, i) => {
       menuItem.tabIndex = i === index ? 0 : -1 // eslint-disable-line no-param-reassign
     })
   }

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -63,7 +63,9 @@ export class LeuMenuItem extends LitElement {
     /* eslint-disable lit/binding-positions, lit/no-invalid-html */
     return html`<${unsafeStatic(
       this.getTagName()
-    )} class="button" href=${ifDefined(this.href)} ?disabled=${this.disabled}>
+    )} class="button" href=${ifDefined(this.href)} ?disabled=${
+      this.disabled
+    } role="menuitem">
       <slot class="before" name="before"></slot>
       <span class="label"><slot></slot></span>
       <slot class="after" name="after"></slot>

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -22,18 +22,6 @@ export class LeuMenuItem extends LitElement {
   }
 
   static properties = {
-    /**
-     * Can be either an icon name or a text
-     * If no icon with this value is found, it will be displayed as text.
-     * If the value is "EMPTY", an empty placeholder with the size of an icon will be displayed.
-     */
-    before: { type: String, reflect: true },
-    /**
-     * Can be either an icon name or a text
-     * If no icon with this value is found, it will be displayed as text
-     * If the value is "EMPTY", an empty placeholder with the size of an icon will be displayed.
-     */
-    after: { type: String, reflect: true },
     active: { type: Boolean, reflect: true },
     highlighted: { type: Boolean, reflect: true },
     disabled: { type: Boolean, reflect: true },

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -72,12 +72,16 @@ export class LeuMenuItem extends LitElement {
   }
 
   getAria() {
+    const commonAttributes = {
+      disabled: this.disabled,
+    }
+
     if (this.href) {
-      return {}
+      return commonAttributes
     }
 
     return {
-      disabled: this.disabled,
+      ...commonAttributes,
       checked:
         this.componentRole === "menuitemcheckbox" ||
         this.componentRole === "menuitemradio"

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -7,6 +7,10 @@ import styles from "./menu-item.css"
 import "../icon/leu-icon.js"
 
 /**
+ * @typedef {'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'option' | 'none'} MenuItemRole
+ */
+
+/**
  * @tagname leu-menu-item
  * @slot - The label of the menu item
  */
@@ -27,6 +31,7 @@ export class LeuMenuItem extends LitElement {
     disabled: { type: Boolean, reflect: true },
     label: { type: String, reflect: true },
     href: { type: String, reflect: true },
+    componentRole: { type: String, reflect: true },
   }
 
   constructor() {
@@ -40,6 +45,9 @@ export class LeuMenuItem extends LitElement {
      * This is just a visual effect and does not change the active state.
      */
     this.highlighted = false
+
+    /** @type {MenuItemRole} */
+    this.componentRole = "menuitem"
   }
 
   connectedCallback() {
@@ -63,14 +71,32 @@ export class LeuMenuItem extends LitElement {
     return this.href ? "a" : "button"
   }
 
+  getAria() {
+    return {
+      "aria-disabled": this.disabled,
+      "aria-checked":
+        this.componentRole === "menuitemcheckbox" ||
+        this.componentRole === "menuitemradio"
+          ? this.active
+          : undefined,
+      "aria-selected":
+        this.componentRole === "option" ? this.active : undefined,
+      role: this.componentRole === "none" ? undefined : this.componentRole,
+    }
+  }
+
   render() {
+    const aria = this.getAria()
+
     /* The eslint rules don't recognize html import from lit/static-html.js */
     /* eslint-disable lit/binding-positions, lit/no-invalid-html */
     return html`<${unsafeStatic(
       this.getTagName()
     )} class="button" href=${ifDefined(this.href)} aria-disabled=${ifDefined(
-      this.disabled
-    )} role="menuitem">
+      aria.disabled
+    )} aria-checked=${ifDefined(aria.checked)} aria-selected=${
+      aria.selected
+    } role=${ifDefined(aria.role)}>
       <slot class="before" name="before"></slot>
       <span class="label"><slot></slot></span>
       <slot class="after" name="after"></slot>

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -54,6 +54,23 @@ export class LeuMenuItem extends LitElement {
     this.highlighted = false
   }
 
+  connectedCallback() {
+    super.connectedCallback()
+    this.addEventListener("click", this._handleClick, true)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+    this.removeEventListener("click", this._handleClick, true)
+  }
+
+  _handleClick(event) {
+    if (this.disabled) {
+      event.stopPropagation()
+      event.preventDefault()
+    }
+  }
+
   getTagName() {
     return this.href ? "a" : "button"
   }
@@ -63,9 +80,9 @@ export class LeuMenuItem extends LitElement {
     /* eslint-disable lit/binding-positions, lit/no-invalid-html */
     return html`<${unsafeStatic(
       this.getTagName()
-    )} class="button" href=${ifDefined(this.href)} ?disabled=${
+    )} class="button" href=${ifDefined(this.href)} aria-disabled=${ifDefined(
       this.disabled
-    } role="menuitem">
+    )} role="menuitem">
       <slot class="before" name="before"></slot>
       <span class="label"><slot></slot></span>
       <slot class="after" name="after"></slot>

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -72,6 +72,10 @@ export class LeuMenuItem extends LitElement {
   }
 
   getAria() {
+    if (this.href) {
+      return {}
+    }
+
     return {
       "aria-disabled": this.disabled,
       "aria-checked":
@@ -94,9 +98,9 @@ export class LeuMenuItem extends LitElement {
       this.getTagName()
     )} class="button" href=${ifDefined(this.href)} aria-disabled=${ifDefined(
       aria.disabled
-    )} aria-checked=${ifDefined(aria.checked)} aria-selected=${
+    )} aria-checked=${ifDefined(aria.checked)} aria-selected=${ifDefined(
       aria.selected
-    } role=${ifDefined(aria.role)}>
+    )} role=${ifDefined(aria.role)}>
       <slot class="before" name="before"></slot>
       <span class="label"><slot></slot></span>
       <slot class="after" name="after"></slot>

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -77,14 +77,13 @@ export class LeuMenuItem extends LitElement {
     }
 
     return {
-      "aria-disabled": this.disabled,
-      "aria-checked":
+      disabled: this.disabled,
+      checked:
         this.componentRole === "menuitemcheckbox" ||
         this.componentRole === "menuitemradio"
           ? this.active
           : undefined,
-      "aria-selected":
-        this.componentRole === "option" ? this.active : undefined,
+      selected: this.componentRole === "option" ? this.active : undefined,
       role: this.componentRole === "none" ? undefined : this.componentRole,
     }
   }

--- a/src/components/menu/menu-item.css
+++ b/src/components/menu/menu-item.css
@@ -43,6 +43,7 @@
 }
 
 .button:hover,
+.button:focus-visible,
 :host([highlighted]) .button {
   --background: var(--background-hover);
 }

--- a/src/components/menu/menu-item.css
+++ b/src/components/menu/menu-item.css
@@ -55,7 +55,7 @@
 :host([disabled]) .button {
   --background: var(--background-disabled);
   --color: var(--color-disabled);
-  cursor: default;
+  cursor: not-allowed;
 }
 
 :is(.before, .after) leu-icon {

--- a/src/components/menu/stories/menu.stories.js
+++ b/src/components/menu/stories/menu.stories.js
@@ -2,6 +2,7 @@ import { html } from "lit"
 import "../leu-menu.js"
 import "../leu-menu-item.js"
 import "../../icon/leu-icon.js"
+import { ifDefined } from "lit/directives/if-defined.js"
 
 export default {
   title: "Menu",
@@ -12,10 +13,23 @@ export default {
       url: "https://www.figma.com/file/d6Pv21UVUbnBs3AdcZijHmbN/KTZH-Design-System?type=design&node-id=17340-82208&mode=design&t=lzVrtq8lxYVJU5TB-11",
     },
   },
+  argTypes: {
+    selects: {
+      control: "select",
+      options: ["single", "multiple"],
+    },
+    role: {
+      control: "select",
+      options: ["menu", "listbox"],
+    },
+  },
 }
 
-function Template() {
-  return html` <leu-menu>
+function Template(args) {
+  return html` <leu-menu
+    role=${ifDefined(args.role)}
+    selects=${ifDefined(args.selects)}
+  >
     <leu-menu-item
       ><leu-icon slot="before"></leu-icon>Menu Item 1</leu-menu-item
     >

--- a/src/components/menu/test/menu-item.test.js
+++ b/src/components/menu/test/menu-item.test.js
@@ -1,19 +1,29 @@
 import { html } from "lit"
-import { fixture, expect, oneEvent } from "@open-wc/testing"
+import { fixture, expect, oneEvent, elementUpdated } from "@open-wc/testing"
 import { ifDefined } from "lit/directives/if-defined.js"
 import { spy } from "sinon"
 
+import "../leu-menu.js"
 import "../leu-menu-item.js"
 
 async function defaultFixture(args = {}) {
   return fixture(html`
     <leu-menu-item
       href=${ifDefined(args.href)}
+      componentRole=${ifDefined(args.componentRole)}
       ?active=${args.active}
       ?disabled=${args.disabled}
     >
       ${args.label}
     </leu-menu-item>
+  `)
+}
+
+async function wrappedFixture(args = {}) {
+  return fixture(html`
+    <leu-menu role=${ifDefined(args.menuRole)}>
+      ${await defaultFixture(args)}
+    </leu-menu>
   `)
 }
 
@@ -25,18 +35,19 @@ describe("LeuMenuItem", () => {
   })
 
   it("passes the a11y audit", async () => {
-    const el = await defaultFixture({ label: "Download" })
+    const el = await wrappedFixture({ label: "Download" })
 
-    await expect(el).shadowDom.to.be.accessible()
+    await expect(el).dom.to.be.accessible()
   })
 
   it("passes the a11y audit with a link", async () => {
-    const el = await defaultFixture({
+    const el = await wrappedFixture({
       label: "Download",
       href: "https://zh.ch",
+      menuRole: "none",
     })
 
-    await expect(el).shadowDom.to.be.accessible()
+    await expect(el).dom.to.be.accessible()
   })
 
   it("renders a label", async () => {
@@ -66,11 +77,58 @@ describe("LeuMenuItem", () => {
     expect(el).to.have.trimmed.text("Kanton Zürich")
   })
 
-  it("passes the disabled attribute to the button", async () => {
+  it("sets the aria-disabled attribute to the button", async () => {
     const el = await defaultFixture({ label: "Download", disabled: true })
 
     const button = el.shadowRoot.querySelector("button")
-    expect(button).to.have.attribute("disabled")
+    expect(button).to.have.attribute("aria-disabled", "true")
+  })
+
+  it("sets the defined role on the button", async () => {
+    const el = await defaultFixture({
+      label: "Download",
+    })
+
+    const button = el.shadowRoot.querySelector("button")
+    expect(button).to.have.attribute("role", "menuitem")
+
+    el.componentRole = "menuitemcheckbox"
+    await elementUpdated(el)
+    expect(button).to.have.attribute("role", "menuitemcheckbox")
+
+    el.componentRole = "menuitemradio"
+    await elementUpdated(el)
+    expect(button).to.have.attribute("role", "menuitemradio")
+
+    el.componentRole = "option"
+    await elementUpdated(el)
+    expect(button).to.have.attribute("role", "option")
+
+    el.componentRole = "none"
+    await elementUpdated(el)
+    expect(button).to.not.have.attribute("role")
+  })
+
+  it("adds either the aria-checked or aria-selected attribute to the button when the item is active", async () => {
+    const el = await defaultFixture({
+      label: "Download",
+      componentRole: "option",
+      active: true,
+    })
+
+    const button = el.shadowRoot.querySelector("button")
+    expect(button).to.have.attribute("aria-selected", "true")
+    expect(button).not.to.have.attribute("aria-checked")
+
+    el.componentRole = "menuitemcheckbox"
+    await elementUpdated(el)
+    expect(button).to.have.attribute("aria-checked", "true")
+    expect(button).not.to.have.attribute("aria-selected")
+
+    el.componentRole = "menuitemradio"
+    await elementUpdated(el)
+    expect(button).to.have.attribute("aria-checked", "true")
+    expect(button).not.to.have.attribute("aria-selected")
   })
 
   it("lets the click event bubble up", async () => {

--- a/src/lib/a11y.js
+++ b/src/lib/a11y.js
@@ -1,0 +1,26 @@
+/**
+ * All roles that are associated with a aria-checked attribute
+ * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked
+ */
+export const ARIA_CHECKED_ROLES = [
+  "checkbox",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "switch",
+]
+
+/**
+ * All roles that are associated with a aria-selected attribute
+ * @link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected
+ */
+export const ARIA_SELECTED_ROLES = [
+  "gridcell",
+  "option",
+  "row",
+  "tab",
+  "columnheader",
+  "rowheader",
+  "treeitem",
+]


### PR DESCRIPTION
- Implement roving tabindex within the menu component
- All components that use the menu component can now just focus the menu element and the rest is handled by the menu itself.
- The Menu component adjusts the role of menu-item children depending on its own role attribute. (role=menu > role=menuitem or role=listbox > role=option)
- button: set aria-expanded on the actual interactive element
- MenuItem: Allow disabled menuitems to receive focus, so that screenreaders announce the existence of disabled items.