### PR TITLE
Reimplement Select

### DIFF
--- a/src/components/chip/chip.css
+++ b/src/components/chip/chip.css
@@ -60,6 +60,7 @@
   padding: 0.5rem 1rem;
 
   color: var(--chip-color);
+  font-family: inherit;
   font-size: 0.875rem;
   line-height: 1rem;
 

--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -79,18 +79,15 @@ export class LeuDropdown extends LeuElement {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
       event.preventDefault()
       const menu = this._getMenu()
-      const menuItems = menu.getMenuItems()
 
       this.expanded = true
 
       await this.updateComplete
 
       if (event.key === "ArrowDown" || event.key === "Home") {
-        menu.setCurrentItem(0)
-        menuItems[0].focus()
+        menu.focusItem(0)
       } else if (event.key === "ArrowUp" || event.key === "End") {
-        menu.setCurrentItem(menuItems.length - 1)
-        menuItems[menuItems.length - 1].focus()
+        menu.focusItem(-1)
       }
     }
   }

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -11,6 +11,7 @@ import styles from "./menu.css"
 
 /**
  * @tagname leu-menu
+ * @property {SelectsType} selects - This has only an effect when the role is 'menu'. It defines which role the menu items will get. Default is 'none'.
  */
 export class LeuMenu extends LeuElement {
   static styles = styles

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -96,7 +96,7 @@ export class LeuMenu extends LeuElement {
       event.preventDefault()
 
       const menuItems = this.getVisibleMenuItems()
-      let index = menuItems.findIndex((menuItem) => menuItem.tabIndex === 0)
+      let index = menuItems.findIndex((menuItem) => menuItem.tabbable)
 
       if (event.key === "ArrowDown") {
         index += 1
@@ -121,9 +121,9 @@ export class LeuMenu extends LeuElement {
     menuItems.forEach((menuItem, i) => {
       if (i === currentItemIndex) {
         currentItem = menuItem
-        menuItem.tabIndex = 0 // eslint-disable-line no-param-reassign
+        menuItem.tabbable = true // eslint-disable-line no-param-reassign
       } else {
-        menuItem.tabIndex = -1 // eslint-disable-line no-param-reassign
+        menuItem.tabbable = false // eslint-disable-line no-param-reassign
       }
     })
 

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -2,6 +2,7 @@ import { html } from "lit"
 
 import { LeuElement } from "../../lib/LeuElement.js"
 
+import { LeuMenuItem } from "./MenuItem.js"
 import styles from "./menu.css"
 
 /**
@@ -13,6 +14,11 @@ import styles from "./menu.css"
  */
 export class LeuMenu extends LeuElement {
   static styles = styles
+
+  static shadowRootOptions = {
+    ...LeuElement.shadowRootOptions,
+    delegatesFocus: true,
+  }
 
   static properties = {
     selects: { type: String, reflect: true },
@@ -33,6 +39,7 @@ export class LeuMenu extends LeuElement {
     }
 
     this.addEventListener("keydown", this._handleKeyDown)
+    this.addEventListener("focus", console.log)
   }
 
   disconnectedCallback() {
@@ -76,7 +83,7 @@ export class LeuMenu extends LeuElement {
     const slot = this.shadowRoot.querySelector("slot")
     return slot
       .assignedElements({ flatten: true })
-      .filter((el) => el.tagName.toLowerCase() === "leu-menu-item")
+      .filter((el) => el instanceof LeuMenuItem)
   }
 
   _handleKeyDown(event) {
@@ -109,6 +116,10 @@ export class LeuMenu extends LeuElement {
     this.getMenuItems().forEach((menuItem, i) => {
       menuItem.tabIndex = i === index ? 0 : -1 // eslint-disable-line no-param-reassign
     })
+  }
+
+  firstUpdated() {
+    this.setCurrentItem(0)
   }
 
   updated(changedProperties) {

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -39,7 +39,6 @@ export class LeuMenu extends LeuElement {
     }
 
     this.addEventListener("keydown", this._handleKeyDown)
-    this.addEventListener("focus", console.log)
   }
 
   disconnectedCallback() {
@@ -103,19 +102,31 @@ export class LeuMenu extends LeuElement {
         index = menuItems.length - 1
       }
 
-      // When the index is out of bounds, it will wrap around to allow
-      // circular navigation
-      index = (index + menuItems.length) % menuItems.length
-
-      this.setCurrentItem(index)
-      menuItems[index].focus()
+      this.focusItem(index)
     }
   }
 
   setCurrentItem(index) {
-    this.getMenuItems().forEach((menuItem, i) => {
-      menuItem.tabIndex = i === index ? 0 : -1 // eslint-disable-line no-param-reassign
+    const menuItems = this.getMenuItems()
+    let currentItem = null
+
+    const currentItemIndex = (index + menuItems.length) % menuItems.length
+
+    menuItems.forEach((menuItem, i) => {
+      if (i === currentItemIndex) {
+        currentItem = menuItem
+        menuItem.tabIndex = 0 // eslint-disable-line no-param-reassign
+      } else {
+        menuItem.tabIndex = -1 // eslint-disable-line no-param-reassign
+      }
     })
+
+    return currentItem
+  }
+
+  focusItem(index) {
+    const currentItem = this.setCurrentItem(index)
+    currentItem.focus()
   }
 
   firstUpdated() {

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -29,6 +29,8 @@ export class LeuMenu extends LeuElement {
 
     /** @type {SelectsType} */
     this.selects = "none"
+
+    this.value = undefined
   }
 
   connectedCallback() {
@@ -85,11 +87,15 @@ export class LeuMenu extends LeuElement {
       .filter((el) => el instanceof LeuMenuItem)
   }
 
+  getVisibleMenuItems() {
+    return this.getMenuItems().filter((menuItem) => !menuItem.hidden)
+  }
+
   _handleKeyDown(event) {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
       event.preventDefault()
 
-      const menuItems = this.getMenuItems()
+      const menuItems = this.getVisibleMenuItems()
       let index = menuItems.findIndex((menuItem) => menuItem.tabIndex === 0)
 
       if (event.key === "ArrowDown") {
@@ -107,7 +113,7 @@ export class LeuMenu extends LeuElement {
   }
 
   setCurrentItem(index) {
-    const menuItems = this.getMenuItems()
+    const menuItems = this.getVisibleMenuItems()
     let currentItem = null
 
     const currentItemIndex = (index + menuItems.length) % menuItems.length

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -35,6 +35,7 @@ export class LeuMenuItem extends LeuElement {
     disabled: { type: Boolean, reflect: true },
     label: { type: String, reflect: true },
     href: { type: String, reflect: true },
+    value: { type: String, reflect: true },
     componentRole: { type: String, reflect: true },
   }
 

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -33,7 +33,6 @@ export class LeuMenuItem extends LeuElement {
     active: { type: Boolean, reflect: true },
     highlighted: { type: Boolean, reflect: true },
     disabled: { type: Boolean, reflect: true },
-    label: { type: String, reflect: true },
     href: { type: String, reflect: true },
     value: { type: String, reflect: true },
     componentRole: { type: String, reflect: true },
@@ -44,6 +43,8 @@ export class LeuMenuItem extends LeuElement {
 
     this.active = false
     this.disabled = false
+    this.value = undefined
+    this.href = undefined
 
     /**
      * A programmatic way to highlight the menu item like it is hovered.
@@ -70,6 +71,10 @@ export class LeuMenuItem extends LeuElement {
       event.stopPropagation()
       event.preventDefault()
     }
+  }
+
+  getValue() {
+    return this.value || this.textContent
   }
 
   getTagName() {

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -33,6 +33,7 @@ export class LeuMenuItem extends LeuElement {
     active: { type: Boolean, reflect: true },
     highlighted: { type: Boolean, reflect: true },
     disabled: { type: Boolean, reflect: true },
+    tabbable: { type: Boolean, reflect: true },
     href: { type: String, reflect: true },
     value: { type: String, reflect: true },
     componentRole: { type: String, reflect: true },
@@ -45,6 +46,7 @@ export class LeuMenuItem extends LeuElement {
     this.disabled = false
     this.value = undefined
     this.href = undefined
+    this.tabbable = undefined
 
     /**
      * A programmatic way to highlight the menu item like it is hovered.
@@ -102,6 +104,14 @@ export class LeuMenuItem extends LeuElement {
     }
   }
 
+  _getTabIndex() {
+    if (typeof this.tabbable === "boolean") {
+      return this.tabbable ? 0 : -1
+    }
+
+    return undefined
+  }
+
   render() {
     const aria = this.getAria()
 
@@ -113,7 +123,7 @@ export class LeuMenuItem extends LeuElement {
       aria.disabled
     )} aria-checked=${ifDefined(aria.checked)} aria-selected=${ifDefined(
       aria.selected
-    )} role=${ifDefined(aria.role)}>
+    )} role=${ifDefined(aria.role)} tabindex=${ifDefined(this._getTabIndex())}>
       <slot class="before" name="before"></slot>
       <span class="label"><slot></slot></span>
       <slot class="after" name="after"></slot>

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -13,6 +13,12 @@ import styles from "./menu-item.css"
 /**
  * @tagname leu-menu-item
  * @slot - The label of the menu item
+ * @property {boolean} active - Defines if the item is selected or checked
+ * @property {boolean} disabled - Disables the underlying button or link
+ * @property {string} value - The value of the item. See `getValue()`
+ * @property {string} href - The href of the underlying link
+ * @property {boolean} tabbable - If the item should be focusable. Will be reflected as `tabindex` to the underlying button or link
+ * @property {MenuItemRole} componentRole - The role of the item. This will be reflected as `role` to the underlying button or link. Default is `'menuitem'.`
  */
 export class LeuMenuItem extends LeuElement {
   static dependencies = {
@@ -75,6 +81,10 @@ export class LeuMenuItem extends LeuElement {
     }
   }
 
+  /**
+   * Returns the value of the item. If `value` is not set, it will return the inner text
+   * @returns {string}
+   */
   getValue() {
     return this.value || this.innerText
   }

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -15,7 +15,7 @@ import styles from "./menu-item.css"
  * @slot - The label of the menu item
  * @property {boolean} active - Defines if the item is selected or checked
  * @property {boolean} disabled - Disables the underlying button or link
- * @property {string} value - The value of the item. See `getValue()`
+ * @property {string} value - The value of the item. It must not contain commas. See `getValue()`
  * @property {string} href - The href of the underlying link
  * @property {boolean} tabbable - If the item should be focusable. Will be reflected as `tabindex` to the underlying button or link
  * @property {MenuItemRole} componentRole - The role of the item. This will be reflected as `role` to the underlying button or link. Default is `'menuitem'.`

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -76,7 +76,7 @@ export class LeuMenuItem extends LeuElement {
   }
 
   getValue() {
-    return this.value || this.textContent
+    return this.value || this.innerText
   }
 
   getTagName() {

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -37,7 +37,6 @@ export class LeuMenuItem extends LeuElement {
 
   static properties = {
     active: { type: Boolean, reflect: true },
-    highlighted: { type: Boolean, reflect: true },
     disabled: { type: Boolean, reflect: true },
     tabbable: { type: Boolean, reflect: true },
     href: { type: String, reflect: true },
@@ -53,12 +52,6 @@ export class LeuMenuItem extends LeuElement {
     this.value = undefined
     this.href = undefined
     this.tabbable = undefined
-
-    /**
-     * A programmatic way to highlight the menu item like it is hovered.
-     * This is just a visual effect and does not change the active state.
-     */
-    this.highlighted = false
 
     /** @type {MenuItemRole} */
     this.componentRole = "menuitem"

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -1,4 +1,4 @@
-import { html, unsafeStatic } from "lit/static-html.js"
+import { html } from "lit"
 import { ifDefined } from "lit/directives/if-defined.js"
 
 import { LeuElement } from "../../lib/LeuElement.js"
@@ -79,11 +79,7 @@ export class LeuMenuItem extends LeuElement {
     return this.value || this.innerText
   }
 
-  getTagName() {
-    return this.href ? "a" : "button"
-  }
-
-  getAria() {
+  _getAria() {
     const commonAttributes = {
       disabled: this.disabled,
     }
@@ -112,22 +108,43 @@ export class LeuMenuItem extends LeuElement {
     return undefined
   }
 
-  render() {
-    const aria = this.getAria()
+  _renderLink(content) {
+    const aria = this._getAria()
 
-    /* The eslint rules don't recognize html import from lit/static-html.js */
-    /* eslint-disable lit/binding-positions, lit/no-invalid-html */
-    return html`<${unsafeStatic(
-      this.getTagName()
-    )} class="button" href=${ifDefined(this.href)} aria-disabled=${ifDefined(
-      aria.disabled
-    )} aria-checked=${ifDefined(aria.checked)} aria-selected=${ifDefined(
-      aria.selected
-    )} role=${ifDefined(aria.role)} tabindex=${ifDefined(this._getTabIndex())}>
+    return html`<a
+      class="button"
+      href=${this.href}
+      aria-disabled=${ifDefined(aria.disabled)}
+      aria-checked=${ifDefined(aria.checked)}
+      aria-selected=${ifDefined(aria.selected)}
+      role=${ifDefined(aria.role)}
+      tabindex=${ifDefined(this._getTabIndex())}
+      >${content}</a
+    >`
+  }
+
+  _renderButton(content) {
+    const aria = this._getAria()
+
+    return html`<button
+      class="button"
+      aria-disabled=${ifDefined(aria.disabled)}
+      aria-checked=${ifDefined(aria.checked)}
+      aria-selected=${ifDefined(aria.selected)}
+      role=${ifDefined(aria.role)}
+      tabindex=${ifDefined(this._getTabIndex())}
+    >
+      ${content}
+    </button>`
+  }
+
+  render() {
+    const content = html`
       <slot class="before" name="before"></slot>
       <span class="label"><slot></slot></span>
       <slot class="after" name="after"></slot>
-    </${unsafeStatic(this.getTagName())}>`
-    /* eslint-enable lit/binding-positions, lit/no-invalid-html */
+    `
+
+    return this.href ? this._renderLink(content) : this._renderButton(content)
   }
 }

--- a/src/components/menu/menu-item.css
+++ b/src/components/menu/menu-item.css
@@ -43,8 +43,7 @@
 }
 
 .button:hover,
-.button:focus-visible,
-:host([highlighted]) .button {
+.button:focus-visible {
   --background: var(--background-hover);
 }
 

--- a/src/components/menu/menu-item.css
+++ b/src/components/menu/menu-item.css
@@ -29,6 +29,7 @@
 
   padding: 0.75rem;
 
+  font-family: inherit;
   font-size: 1rem;
   line-height: 1.5;
   text-align: left;

--- a/src/components/menu/test/menu-item.test.js
+++ b/src/components/menu/test/menu-item.test.js
@@ -11,8 +11,10 @@ async function defaultFixture(args = {}) {
     <leu-menu-item
       href=${ifDefined(args.href)}
       componentRole=${ifDefined(args.componentRole)}
+      value=${ifDefined(args.value)}
       ?active=${args.active}
       ?disabled=${args.disabled}
+      ?tabbable=${args.tabbable}
     >
       ${args.label}
     </leu-menu-item>
@@ -155,5 +157,30 @@ describe("LeuMenuItem", () => {
     el.click()
 
     expect(clickSpy).to.have.not.been.called
+  })
+
+  it("reflects the tabbable property as tabindex to the button", async () => {
+    const el = await defaultFixture({ label: "Download", tabbable: true })
+
+    const button = el.shadowRoot.querySelector("button")
+    expect(button).to.have.attribute("tabindex", "0")
+
+    el.tabbable = false
+    await elementUpdated(el)
+    expect(button).to.have.attribute("tabindex", "-1")
+
+    el.tabbable = undefined
+    await elementUpdated(el)
+    expect(button).to.not.have.attribute("tabindex")
+  })
+
+  it("returns the value or label when getValue is called", async () => {
+    const el = await defaultFixture({ label: "Download          " })
+
+    expect(el.getValue()).to.equal("Download")
+
+    el.value = "download-01"
+
+    expect(el.getValue()).to.equal("download-01")
   })
 })

--- a/src/components/menu/test/menu.test.js
+++ b/src/components/menu/test/menu.test.js
@@ -1,12 +1,17 @@
 import { html } from "lit"
+import { ifDefined } from "lit/directives/if-defined.js"
 import { fixture, expect } from "@open-wc/testing"
+import { sendKeys } from "@web/test-runner-commands"
 
 import "../leu-menu.js"
 import "../leu-menu-item.js"
 import "../../icon/leu-icon.js"
 
-async function defaultFixture() {
-  return fixture(html` <leu-menu>
+async function defaultFixture(args = {}) {
+  return fixture(html` <leu-menu
+    role=${ifDefined(args.role)}
+    selects=${ifDefined(args.selects)}
+  >
     <leu-menu-item
       ><leu-icon slot="before"></leu-icon>Menu Item 1</leu-menu-item
     >
@@ -39,5 +44,80 @@ describe("LeuMenu", () => {
     const el = await defaultFixture()
 
     await expect(el).dom.to.be.accessible()
+  })
+
+  it("sets 'menu' as the default role", async () => {
+    const el = await defaultFixture()
+
+    expect(el.getAttribute("role")).to.equal("menu")
+  })
+
+  it("sets 'menuitem' as the default role for menu items", async () => {
+    const el = await defaultFixture()
+
+    const menuItems = el.querySelectorAll("leu-menu-item")
+
+    menuItems.forEach((menuItem) => {
+      expect(menuItem.componentRole).to.equal("menuitem")
+    })
+  })
+
+  it("sets 'menuitemradio' as the role for menu items when only one item can be selected", async () => {
+    const el = await defaultFixture({ selects: "single" })
+
+    const menuItems = el.querySelectorAll("leu-menu-item")
+
+    menuItems.forEach((menuItem) => {
+      expect(menuItem.componentRole).to.equal("menuitemradio")
+    })
+  })
+
+  it("sets 'menuitemcheckbox' as the role for menu items when multiple items can be selected", async () => {
+    const el = await defaultFixture({ selects: "multiple" })
+
+    const menuItems = el.querySelectorAll("leu-menu-item")
+
+    menuItems.forEach((menuItem) => {
+      expect(menuItem.componentRole).to.equal("menuitemcheckbox")
+    })
+  })
+
+  it("sets 'option' as the role for menu items when the menu role is 'listbox'", async () => {
+    const el = await defaultFixture({ role: "listbox" })
+
+    const menuItems = el.querySelectorAll("leu-menu-item")
+
+    menuItems.forEach((menuItem) => {
+      expect(menuItem.componentRole).to.equal("option")
+    })
+  })
+
+  it("moves the focus when the arrow keys are pressed", async () => {
+    const el = await defaultFixture()
+
+    const menuItems = Array.from(el.querySelectorAll("leu-menu-item"))
+
+    await sendKeys({ press: "Tab" })
+    expect(document.activeElement).to.equal(menuItems[0])
+
+    await sendKeys({ press: "ArrowDown" })
+    await sendKeys({ press: "ArrowDown" })
+
+    expect(document.activeElement).to.equal(menuItems[2])
+
+    await sendKeys({ press: "ArrowUp" })
+    await sendKeys({ press: "ArrowUp" })
+    await sendKeys({ press: "ArrowUp" })
+
+    expect(document.activeElement).to.equal(menuItems.at(-1))
+
+    await sendKeys({ press: "Home" })
+    expect(document.activeElement).to.equal(menuItems[0])
+
+    await sendKeys({ press: "End" })
+    expect(document.activeElement).to.equal(menuItems.at(-1))
+
+    await sendKeys({ press: "ArrowDown" })
+    expect(document.activeElement).to.equal(menuItems[0])
   })
 })

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -2,6 +2,7 @@ import { html, nothing } from "lit"
 import { classMap } from "lit/directives/class-map.js"
 import { createRef, ref } from "lit/directives/ref.js"
 
+import { ifDefined } from "lit/directives/if-defined.js"
 import { LeuElement } from "../../lib/LeuElement.js"
 import { HasSlotController } from "../../lib/hasSlotController.js"
 
@@ -442,6 +443,9 @@ export class LeuSelect extends LeuElement {
             <leu-menu
               ref=${ref(this._menuRef)}
               role="listbox"
+              aria-multiselectable=${ifDefined(
+                this.multiple ? "true" : undefined
+              )}
               class="menu"
               @click=${this._handleMenuItemClick}
             >

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -343,13 +343,15 @@ export class LeuSelect extends LeuElement {
   _renderApplyButton() {
     if (this.multiple) {
       return html`
-        <leu-button
-          type="button"
-          class="apply-button"
-          @click=${this._handleApplyClick}
-          fluid
-          >Anwenden</leu-button
-        >
+        <div class="apply-button-wrapper">
+          <leu-button
+            type="button"
+            class="apply-button"
+            @click=${this._handleApplyClick}
+            fluid
+            >Anwenden</leu-button
+          >
+        </div>
       `
     }
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -347,7 +347,6 @@ export class LeuSelect extends LeuElement {
    */
   _handlePopupFocusOut(event) {
     if (
-      event.relatedTarget !== null &&
       !this.contains(event.relatedTarget) &&
       !this.shadowRoot.contains(event.relatedTarget)
     ) {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -20,9 +20,15 @@ import styles from "./select.css"
  * @tagname leu-select
  * @slot before - Optional content the appears before the option list
  * @slot after - Optional content the appears after the option list
- *
- * Values of the leu-menu-item elements are used as the value of the select.
- * The values must not contain commas.
+ * @property {string} name - Reflects to the name attribute of the hidden input field that would be used in a form
+ * @property {boolean} open - The expanded state of the popup
+ * @property {string} label - The label of the select
+ * @property {array} value - List of selected values. If they're set from outside the component, the select element tries to find all the options with the given values and selects them.
+ * @property {boolean} clearable - Show a clearable button to reset the value
+ * @property {boolean} disabled - If the select should be disabled
+ * @property {boolean} filterable - Show an input field to filter the options inside the popup
+ * @property {boolean} multiple - Allow multiple selections
+ * @attribute {string} value - The selected values separated by commas.
  */
 export class LeuSelect extends LeuElement {
   static dependencies = {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -174,7 +174,11 @@ export class LeuSelect extends LeuElement {
       }
 
       if (changed.value) {
-        menuItem.active = this._isSelected(menuItem.value)
+        menuItem.active = this._isSelected(menuItem.getValue())
+
+        if (!this.multiple && menuItem.active) {
+          this._displayValue = menuItem.textContent
+        }
       }
     })
     /* eslint-enable no-param-reassign */

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -107,6 +107,11 @@ export class LeuSelect extends LeuElement {
      * @type {import("lit/directives/ref").Ref<HTMLButtonElement>}
      */
     this._toggleButtonRef = createRef()
+
+    /**
+     * @type {import("lit/directives/ref").Ref<import("../menu/Menu").LeuMenu>}
+     */
+    this._menuRef = createRef()
   }
 
   connectedCallback() {
@@ -124,7 +129,7 @@ export class LeuSelect extends LeuElement {
       if (this.filterable) {
         this._optionFilterRef.value.focus()
       } else {
-        this.querySelector("leu-menu")?.focus()
+        this._menuRef.value.focusItem(0)
       }
     } else if (changedProperties.has("open") && !this.open) {
       this._toggleButtonRef.value.focus()
@@ -148,7 +153,8 @@ export class LeuSelect extends LeuElement {
    */
   async _updateMenuItems(changed) {
     /** @type {LeuMenu} */
-    const menu = this.querySelector("leu-menu")
+    const menu = this._menuRef.value
+
     await menu.updateComplete
 
     const menuItems = menu.getMenuItems()
@@ -207,8 +213,7 @@ export class LeuSelect extends LeuElement {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
       event.preventDefault()
 
-      /** @type {LeuMenu} */
-      const menu = this.querySelector("leu-menu")
+      const menu = this._menuRef.value
 
       this.open = true
       await this.updateComplete
@@ -377,7 +382,6 @@ export class LeuSelect extends LeuElement {
       @keydown=${this._handleToggleKeyDown}
       ?disabled=${this.disabled}
       aria-controls="select-popup"
-      aria-haspopup="listbox"
       aria-expanded="${this.open}"
       aria-labelledby="select-label"
       role="combobox"
@@ -435,11 +439,14 @@ export class LeuSelect extends LeuElement {
           >
             <slot name="before" class="before"></slot>
             ${this._renderFilterInput()}
-            <slot
-              name="menu"
+            <leu-menu
+              ref=${ref(this._menuRef)}
+              role="listbox"
               class="menu"
               @click=${this._handleMenuItemClick}
-            ></slot>
+            >
+              <slot></slot>
+            </leu-menu>
             ${this._hasFilterResults
               ? nothing
               : html` <p class="filter-message-empty" aria-live="polite">

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -47,7 +47,6 @@ export class LeuSelect extends LeuElement {
       name: { type: String, reflect: true },
       open: { type: Boolean, reflect: true },
       label: { type: String, reflect: true },
-      options: { type: Array },
       value: {
         type: Array,
         converter: {
@@ -90,7 +89,6 @@ export class LeuSelect extends LeuElement {
     this.clearable = false
     this.filterable = false
     this.value = []
-    this.options = []
     this.label = ""
     this.name = ""
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -43,7 +43,7 @@ export class LeuSelect extends LeuElement {
       disabled: { type: Boolean, reflect: true },
       filterable: { type: Boolean, reflect: true },
       multiple: { type: Boolean, reflect: true },
-      optionFilter: { state: true },
+      _optionFilter: { state: true },
     }
   }
 
@@ -72,44 +72,44 @@ export class LeuSelect extends LeuElement {
     this.label = ""
 
     /** @internal */
-    this.optionFilter = ""
+    this._optionFilter = ""
 
     /** @internal */
-    this.deferedChangeEvent = false
+    this._deferedChangeEvent = false
 
     /**
      * @type {import("lit/directives/ref").Ref<import("../menu/Menu").LeuMenu>}
      */
-    this.menuRef = createRef()
+    this._menuRef = createRef()
     /**
      * @type {import("lit/directives/ref").Ref<import("../input/Input").LeuInput>}
      */
-    this.optionFilterRef = createRef()
+    this._optionFilterRef = createRef()
     /**
      * @type {import("lit/directives/ref").Ref<HTMLButtonElement>}
      */
-    this.toggleButtonRef = createRef()
+    this._toggleButtonRef = createRef()
   }
 
   connectedCallback() {
     super.connectedCallback()
-    document.addEventListener("click", this.handleDocumentClick)
+    document.addEventListener("click", this._handleDocumentClick)
   }
 
   disconnectedCallback() {
     super.disconnectedCallback()
-    document.removeEventListener("click", this.handleDocumentClick)
+    document.removeEventListener("click", this._handleDocumentClick)
   }
 
   updated(changedProperties) {
     if (changedProperties.has("open") && this.open) {
       if (this.filterable) {
-        this.optionFilterRef.value.focus()
+        this._optionFilterRef.value.focus()
       } else {
         this.querySelector("leu-menu")?.focus()
       }
     } else if (changedProperties.has("open") && !this.open) {
-      this.toggleButtonRef.value.focus()
+      this._toggleButtonRef.value.focus()
     }
   }
 
@@ -118,13 +118,13 @@ export class LeuSelect extends LeuElement {
    * @internal
    * @param {MouseEvent} event
    */
-  handleDocumentClick = (event) => {
+  _handleDocumentClick = (event) => {
     if (
       event.target instanceof Node &&
       !this.contains(event.target) &&
       this.open
     ) {
-      this.closeDropdown()
+      this._closeDropdown()
     }
   }
 
@@ -132,9 +132,9 @@ export class LeuSelect extends LeuElement {
    * @internal
    * @param {KeyboardEvent} e
    */
-  handleKeyDown = (event) => {
+  _handleKeyDown = (event) => {
     if (event.key === "Escape") {
-      this.closeDropdown()
+      this._closeDropdown()
     }
   }
 
@@ -145,7 +145,7 @@ export class LeuSelect extends LeuElement {
       /** @type {LeuMenu} */
       const menu = this.querySelector("leu-menu")
 
-      this.openDropdown()
+      this._openDropdown()
       await this.updateComplete
 
       if (event.key === "ArrowDown" || event.key === "Home") {
@@ -156,7 +156,7 @@ export class LeuSelect extends LeuElement {
     }
   }
 
-  getDisplayValue(value) {
+  _getDisplayValue(value) {
     if (this.multiple) {
       return value.length === 0 ? `` : `${value.length} gewählt`
     }
@@ -164,21 +164,21 @@ export class LeuSelect extends LeuElement {
     return LeuSelect.getOptionLabel(value[0])
   }
 
-  getFilteredOptions() {
-    return this.filterable && this.optionFilter.length > 0
+  _getFilteredOptions() {
+    return this.filterable && this._optionFilter.length > 0
       ? this.options.filter((option) => {
           const label = LeuSelect.getOptionLabel(option)
-          return label.toLowerCase().includes(this.optionFilter.toLowerCase())
+          return label.toLowerCase().includes(this._optionFilter.toLowerCase())
         })
       : this.options
   }
 
-  emitUpdateEvents() {
-    this.emitInputEvent()
-    this.emitChangeEvent()
+  _emitUpdateEvents() {
+    this._emitInputEvent()
+    this._emitChangeEvent()
   }
 
-  emitInputEvent() {
+  _emitInputEvent() {
     const inputevent = new CustomEvent("input", {
       composed: true,
       bubbles: true,
@@ -186,7 +186,7 @@ export class LeuSelect extends LeuElement {
     this.dispatchEvent(inputevent)
   }
 
-  emitChangeEvent() {
+  _emitChangeEvent() {
     const changeevent = new CustomEvent("change", {
       composed: true,
       bubbles: true,
@@ -194,31 +194,31 @@ export class LeuSelect extends LeuElement {
     this.dispatchEvent(changeevent)
   }
 
-  clearValue(event) {
+  _clearValue(event) {
     if (!this.disabled) {
       event.stopPropagation()
       this.value = []
     }
 
-    this.emitUpdateEvents()
+    this._emitUpdateEvents()
   }
 
-  toggleDropdown() {
+  _toggleDropdown() {
     if (!this.disabled) {
       this.open = !this.open
     }
   }
 
-  openDropdown() {
+  _openDropdown() {
     this.open = true
   }
 
-  closeDropdown() {
+  _closeDropdown() {
     this.open = false
 
-    if (this.deferedChangeEvent) {
-      this.emitChangeEvent()
-      this.deferedChangeEvent = false
+    if (this._deferedChangeEvent) {
+      this._emitChangeEvent()
+      this._deferedChangeEvent = false
     }
   }
 
@@ -227,41 +227,41 @@ export class LeuSelect extends LeuElement {
    *
    * @param {*} option
    */
-  selectOption(option) {
-    const isSelected = this.isSelected(option)
+  _selectOption(option) {
+    const isSelected = this._isSelected(option)
 
     if (this.multiple) {
       this.value = isSelected
         ? this.value.filter((v) => v !== option)
         : this.value.concat(option)
 
-      this.deferedChangeEvent = true
+      this._deferedChangeEvent = true
     } else {
       this.value = isSelected ? [] : [option]
     }
 
-    this.emitInputEvent()
+    this._emitInputEvent()
 
     if (!this.multiple) {
-      this.closeDropdown()
+      this._closeDropdown()
     }
   }
 
-  handleApplyClick() {
-    this.closeDropdown()
+  _handleApplyClick() {
+    this._closeDropdown()
   }
 
-  handleFilterInput(event) {
-    this.optionFilter = event.target.value
+  _handleFilterInput(event) {
+    this._optionFilter = event.target.value
   }
 
-  isSelected(option) {
+  _isSelected(option) {
     return this.value.includes(option)
   }
 
-  handleMenuClick(event) {
+  _handleMenuClick(event) {
     if (event.target instanceof LeuMenuItem && event.target.value) {
-      this.selectOption(event.target.value)
+      this._selectOption(event.target.value)
     }
   }
 
@@ -273,17 +273,17 @@ export class LeuSelect extends LeuElement {
       !this.contains(event.relatedTarget) &&
       !this.shadowRoot.contains(event.relatedTarget)
     ) {
-      this.closeDropdown()
+      this._closeDropdown()
     }
   }
 
-  renderMenu() {
+  _renderMenu() {
     const menuClasses = {
       "select-menu": true,
       multiple: this.multiple,
     }
 
-    const filteredOptions = this.getFilteredOptions()
+    const filteredOptions = this._getFilteredOptions()
 
     return html`
       <leu-menu
@@ -291,11 +291,11 @@ export class LeuSelect extends LeuElement {
         class=${classMap(menuClasses)}
         aria-multiselectable="${this.multiple}"
         aria-labelledby="select-label"
-        ref=${ref(this.menuRef)}
+        ref=${ref(this._menuRef)}
       >
         ${filteredOptions.length > 0
-          ? map(this.getFilteredOptions(), (option) => {
-              const isSelected = this.isSelected(option)
+          ? map(this._getFilteredOptions(), (option) => {
+              const isSelected = this._isSelected(option)
               let beforeIcon
 
               if (this.multiple && isSelected) {
@@ -305,7 +305,7 @@ export class LeuSelect extends LeuElement {
               }
 
               return html`<leu-menu-item
-                @click=${() => this.selectOption(option)}
+                @click=${() => this._selectOption(option)}
                 role="option"
                 ?active=${isSelected}
                 aria-selected=${isSelected}
@@ -317,7 +317,7 @@ export class LeuSelect extends LeuElement {
               </leu-menu-item>`
             })
           : html`<leu-menu-item disabled
-              >${this.optionFilter === ""
+              >${this._optionFilter === ""
                 ? "Keine Optionen"
                 : "Keine Resultate"}</leu-menu-item
             >`}
@@ -325,14 +325,14 @@ export class LeuSelect extends LeuElement {
     `
   }
 
-  renderFilterInput() {
+  _renderFilterInput() {
     if (this.filterable) {
       return html` <leu-input
         class="select-search"
         size="small"
-        @input=${this.handleFilterInput}
+        @input=${this._handleFilterInput}
         clearable
-        ref=${ref(this.optionFilterRef)}
+        ref=${ref(this._optionFilterRef)}
         label="Nach Stichwort filtern"
       ></leu-input>`
     }
@@ -340,13 +340,13 @@ export class LeuSelect extends LeuElement {
     return nothing
   }
 
-  renderApplyButton() {
+  _renderApplyButton() {
     if (this.multiple) {
       return html`
         <leu-button
           type="button"
           class="apply-button"
-          @click=${this.handleApplyClick}
+          @click=${this._handleApplyClick}
           fluid
           >Anwenden</leu-button
         >
@@ -356,7 +356,7 @@ export class LeuSelect extends LeuElement {
     return nothing
   }
 
-  renderToggleButton() {
+  _renderToggleButton() {
     const toggleClasses = {
       "select-toggle": true,
       open: this.open,
@@ -367,7 +367,7 @@ export class LeuSelect extends LeuElement {
     return html`<button
       type="button"
       class=${classMap(toggleClasses)}
-      @click=${this.toggleDropdown}
+      @click=${this._toggleDropdown}
       @keydown=${this._handleToggleKeyDown}
       ?disabled=${this.disabled}
       aria-controls="select-popup"
@@ -375,11 +375,11 @@ export class LeuSelect extends LeuElement {
       aria-expanded="${this.open}"
       aria-labelledby="select-label"
       role="combobox"
-      ref=${ref(this.toggleButtonRef)}
+      ref=${ref(this._toggleButtonRef)}
       slot="anchor"
     >
       <span class="label" id="select-label">${this.label}</span>
-      <span class="value"> ${this.getDisplayValue(this.value)} </span>
+      <span class="value"> ${this._getDisplayValue(this.value)} </span>
       <span class="arrow-icon">
         <leu-icon name="angleDropDown"></leu-icon>
       </span>
@@ -387,7 +387,7 @@ export class LeuSelect extends LeuElement {
         ? html`<button
             type="button"
             class="clear-button"
-            @click=${this.clearValue}
+            @click=${this._clearValue}
             aria-label=${`${this.label} zurücksetzen`}
             ?disabled=${this.disabled}
           >
@@ -411,7 +411,7 @@ export class LeuSelect extends LeuElement {
     /* eslint-disable lit-a11y/click-events-have-key-events */
     return html`<div
       class=${classMap(selectClasses)}
-      @keydown=${this.handleKeyDown}
+      @keydown=${this._handleKeyDown}
     >
       <leu-popup
         ?active=${this.open}
@@ -421,16 +421,16 @@ export class LeuSelect extends LeuElement {
         autoSize="height"
         autoSizePadding="8"
       >
-        ${this.renderToggleButton()}
+        ${this._renderToggleButton()}
         <div
           id="select-popup"
           class="select-menu-container"
           @focusout=${this._handlePopupFocusOut}
         >
           <slot name="before" class="before"></slot>
-          ${this.renderFilterInput()}
-          <slot name="menu" @click=${this.handleMenuClick}></slot>
-          ${this.renderApplyButton()}
+          ${this._renderFilterInput()}
+          <slot name="menu" @click=${this._handleMenuClick}></slot>
+          ${this._renderApplyButton()}
           <slot name="after" class="after"></slot>
         </div>
       </leu-popup>

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -58,6 +58,7 @@ export class LeuSelect extends LeuElement {
       multiple: { type: Boolean, reflect: true },
       _optionFilter: { state: true },
       _hasFilterResults: { state: true },
+      _displayValue: { state: true },
     }
   }
 
@@ -94,6 +95,9 @@ export class LeuSelect extends LeuElement {
 
     /** @internal */
     this._deferedChangeEvent = false
+
+    /** @internal */
+    this._displayValue = ""
 
     /**
      * @type {import("lit/directives/ref").Ref<import("../input/Input").LeuInput>}
@@ -155,7 +159,7 @@ export class LeuSelect extends LeuElement {
       if (changed.optionFilter) {
         menuItem.hidden =
           this._optionFilter !== "" &&
-          !menuItem.value
+          !menuItem.textContent
             .toLowerCase()
             .includes(this._optionFilter.toLowerCase())
 
@@ -222,7 +226,7 @@ export class LeuSelect extends LeuElement {
       return value.length === 0 ? `` : `${value.length} gewählt`
     }
 
-    return LeuSelect.getOptionLabel(value[0])
+    return this._displayValue ?? nothing
   }
 
   _getFilteredOptions() {
@@ -289,7 +293,7 @@ export class LeuSelect extends LeuElement {
    * @param {LeuMenuItem} menuItem
    */
   _selectOption(menuItem) {
-    const { value } = menuItem
+    const value = menuItem.getValue()
     const isSelected = this._isSelected(value)
 
     if (this.multiple) {
@@ -300,6 +304,7 @@ export class LeuSelect extends LeuElement {
       this._deferedChangeEvent = true
     } else {
       this.value = isSelected ? [] : [value]
+      this._displayValue = isSelected ? "" : menuItem.textContent
     }
 
     this._emitInputEvent()

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -111,7 +111,6 @@ export class LeuSelect extends LeuElement {
 
   connectedCallback() {
     super.connectedCallback()
-    document.addEventListener("click", this._handleDocumentClick)
   }
 
   disconnectedCallback() {
@@ -329,6 +328,17 @@ export class LeuSelect extends LeuElement {
     }
   }
 
+  /**
+   * Redirect the focus to the first menu item when the menu slot receives focus.
+   * The menu slot itself is not an interactive element but can still receive focus
+   * because the css property `overflow` is set to `auto` and therefore is a scrollable area.
+   */
+  _handleMenuSlotFocus() {
+    /** @type {LeuMenu} */
+    const menu = this.querySelector("leu-menu")
+    menu.focusItem(0)
+  }
+
   _renderFilterInput() {
     if (this.filterable) {
       return html` <leu-input
@@ -438,7 +448,7 @@ export class LeuSelect extends LeuElement {
             <slot
               name="menu"
               class="menu"
-              @click=${this._handleMenuItemClick}
+              @focus=${this._handleMenuSlotFocus}
             ></slot>
             ${this._hasFilterResults
               ? nothing

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -332,9 +332,11 @@ export class LeuSelect extends LeuElement {
       type="button"
       class=${classMap(toggleClasses)}
       @click=${this.toggleDropdown}
+      ?disabled=${this.disabled}
       aria-controls="select-dialog"
       aria-haspopup="dialog"
       aria-expanded="${this.open}"
+      aria-labelledby="select-label"
       role="combobox"
       ref=${ref(this.toggleButtonRef)}
       slot="anchor"
@@ -367,9 +369,6 @@ export class LeuSelect extends LeuElement {
 
     return html`<div
       class=${classMap(selectClasses)}
-      ?disabled=${this.disabled}
-      aria-readonly="${this.disabled}"
-      aria-labelledby="select-label"
       @keydown=${this.handleKeyDown}
     >
       <leu-popup

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -210,6 +210,10 @@ export class LeuSelect extends LeuElement {
     }
   }
 
+  /**
+   * @internal
+   * @param {KeyboardEvent} event
+   */
   async _handleToggleKeyDown(event) {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
       event.preventDefault()
@@ -224,6 +228,18 @@ export class LeuSelect extends LeuElement {
       } else if (event.key === "ArrowUp" || event.key === "End") {
         menu.focusItem(-1)
       }
+    }
+  }
+
+  /**
+   * @internal
+   * @param {KeyboardEvent} event
+   */
+  _handleFilterInputKeyDown(event) {
+    if (event.key === "ArrowDown") {
+      this._menuRef.value.focusItem(0)
+    } else if (event.key === "ArrowUp") {
+      this._menuRef.value.focusItem(-1)
     }
   }
 
@@ -341,6 +357,7 @@ export class LeuSelect extends LeuElement {
         class="select-search"
         size="small"
         @input=${this._handleFilterInput}
+        @keydown=${this._handleFilterInputKeyDown}
         clearable
         ref=${ref(this._optionFilterRef)}
         label="Nach Stichwort filtern"

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -111,6 +111,7 @@ export class LeuSelect extends LeuElement {
 
   connectedCallback() {
     super.connectedCallback()
+    document.addEventListener("click", this._handleDocumentClick)
   }
 
   disconnectedCallback() {
@@ -328,17 +329,6 @@ export class LeuSelect extends LeuElement {
     }
   }
 
-  /**
-   * Redirect the focus to the first menu item when the menu slot receives focus.
-   * The menu slot itself is not an interactive element but can still receive focus
-   * because the css property `overflow` is set to `auto` and therefore is a scrollable area.
-   */
-  _handleMenuSlotFocus() {
-    /** @type {LeuMenu} */
-    const menu = this.querySelector("leu-menu")
-    menu.focusItem(0)
-  }
-
   _renderFilterInput() {
     if (this.filterable) {
       return html` <leu-input
@@ -448,7 +438,7 @@ export class LeuSelect extends LeuElement {
             <slot
               name="menu"
               class="menu"
-              @focus=${this._handleMenuSlotFocus}
+              @click=${this._handleMenuItemClick}
             ></slot>
             ${this._hasFilterResults
               ? nothing

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -138,7 +138,7 @@ export class LeuSelect extends LeuElement {
     }
   }
 
-  _handleToggleKeyDown(event) {
+  async _handleToggleKeyDown(event) {
     if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
       event.preventDefault()
 
@@ -146,6 +146,7 @@ export class LeuSelect extends LeuElement {
       const menu = this.querySelector("leu-menu")
 
       this.openDropdown()
+      await this.updateComplete
 
       if (event.key === "ArrowDown" || event.key === "Home") {
         menu.focusItem(0)
@@ -261,6 +262,18 @@ export class LeuSelect extends LeuElement {
   handleMenuClick(event) {
     if (event.target instanceof LeuMenuItem && event.target.value) {
       this.selectOption(event.target.value)
+    }
+  }
+
+  /**
+   * Close the dropdown if the focus moves outside the component.
+   */
+  _handlePopupFocusOut(event) {
+    if (
+      !this.contains(event.relatedTarget) &&
+      !this.shadowRoot.contains(event.relatedTarget)
+    ) {
+      this.closeDropdown()
     }
   }
 
@@ -391,6 +404,11 @@ export class LeuSelect extends LeuElement {
       "select--has-after": this.hasSlotController.test("after"),
     }
 
+    /*
+     * We use the click event listener with the event delegation pattern
+     * so this is not a violation of the rule.
+     */
+    /* eslint-disable lit-a11y/click-events-have-key-events */
     return html`<div
       class=${classMap(selectClasses)}
       @keydown=${this.handleKeyDown}
@@ -404,7 +422,11 @@ export class LeuSelect extends LeuElement {
         autoSizePadding="8"
       >
         ${this.renderToggleButton()}
-        <div id="select-popup" class="select-menu-container">
+        <div
+          id="select-popup"
+          class="select-menu-container"
+          @focusout=${this._handlePopupFocusOut}
+        >
           <slot name="before" class="before"></slot>
           ${this.renderFilterInput()}
           <slot name="menu" @click=${this.handleMenuClick}></slot>
@@ -413,5 +435,6 @@ export class LeuSelect extends LeuElement {
         </div>
       </leu-popup>
     </div> `
+    /* eslint-enable lit-a11y/click-events-have-key-events */
   }
 }

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -429,7 +429,7 @@ export class LeuSelect extends LeuElement {
         >
           <slot name="before" class="before"></slot>
           ${this._renderFilterInput()}
-          <slot name="menu" @click=${this._handleMenuClick}></slot>
+          <slot name="menu" class="menu" @click=${this._handleMenuClick}></slot>
           ${this._renderApplyButton()}
           <slot name="after" class="after"></slot>
         </div>

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -106,7 +106,7 @@ export class LeuSelect extends LeuElement {
       if (this.filterable) {
         this.optionFilterRef.value.focus()
       } else {
-        this.menuRef.value.focus()
+        this.querySelector("leu-menu")?.focus()
       }
     } else if (changedProperties.has("open") && !this.open) {
       this.toggleButtonRef.value.focus()
@@ -135,6 +135,26 @@ export class LeuSelect extends LeuElement {
   handleKeyDown = (event) => {
     if (event.key === "Escape") {
       this.closeDropdown()
+    }
+  }
+
+  _handleToggleKeyDown(event) {
+    if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      event.preventDefault()
+
+      /** @type {LeuMenu} */
+      const menu = this.querySelector("leu-menu")
+      const menuItems = menu.getMenuItems()
+
+      this.openDropdown()
+
+      if (event.key === "ArrowDown" || event.key === "Home") {
+        menu.setCurrentItem(0)
+        menuItems[0].focus()
+      } else if (event.key === "ArrowUp" || event.key === "End") {
+        menu.setCurrentItem(menuItems.length - 1)
+        menuItems[menuItems.length - 1].focus()
+      }
     }
   }
 
@@ -241,6 +261,12 @@ export class LeuSelect extends LeuElement {
     return this.value.includes(option)
   }
 
+  handleMenuClick(event) {
+    if (event.target instanceof LeuMenuItem && event.target.value) {
+      this.selectOption(event.target.value)
+    }
+  }
+
   renderMenu() {
     const menuClasses = {
       "select-menu": true,
@@ -332,9 +358,10 @@ export class LeuSelect extends LeuElement {
       type="button"
       class=${classMap(toggleClasses)}
       @click=${this.toggleDropdown}
+      @keydown=${this._handleToggleKeyDown}
       ?disabled=${this.disabled}
-      aria-controls="select-dialog"
-      aria-haspopup="dialog"
+      aria-controls="select-popup"
+      aria-haspopup="listbox"
       aria-expanded="${this.open}"
       aria-labelledby="select-label"
       role="combobox"
@@ -380,16 +407,13 @@ export class LeuSelect extends LeuElement {
         autoSizePadding="8"
       >
         ${this.renderToggleButton()}
-        <dialog
-          id="select-dialog"
-          class="select-menu-container"
-          ?open=${this.open}
-        >
+        <div id="select-popup" class="select-menu-container">
           <slot name="before" class="before"></slot>
-          ${this.renderFilterInput()} ${this.renderMenu()}
+          ${this.renderFilterInput()}
+          <slot name="menu" @click=${this.handleMenuClick}></slot>
           ${this.renderApplyButton()}
           <slot name="after" class="after"></slot>
-        </dialog>
+        </div>
       </leu-popup>
     </div> `
   }

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -144,16 +144,13 @@ export class LeuSelect extends LeuElement {
 
       /** @type {LeuMenu} */
       const menu = this.querySelector("leu-menu")
-      const menuItems = menu.getMenuItems()
 
       this.openDropdown()
 
       if (event.key === "ArrowDown" || event.key === "Home") {
-        menu.setCurrentItem(0)
-        menuItems[0].focus()
+        menu.focusItem(0)
       } else if (event.key === "ArrowUp" || event.key === "End") {
-        menu.setCurrentItem(menuItems.length - 1)
-        menuItems[menuItems.length - 1].focus()
+        menu.focusItem(-1)
       }
     }
   }

--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -201,9 +201,13 @@
   display: none;
 }
 
+.apply-button-wrapper {
+  background-color: var(--leu-color-black-10);
+  padding: 0.75rem;
+}
+
 .apply-button {
   display: block;
-  margin: 0.75rem;
 }
 
 .select-search {

--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -213,3 +213,11 @@
 .select-search {
   margin: 0.75rem;
 }
+
+.filter-message-empty {
+  background: var(--leu-color-black-0);
+  color: var(--leu-color-black-transp-60);
+
+  padding: 0.75rem;
+  margin: 0;
+}

--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -171,7 +171,7 @@
   flex-direction: column;
 
   width: 100%;
-  max-height: var(--auto-size-available-height);
+  max-height: min(var(--auto-size-available-height), 24rem);
 
   padding: 0;
   margin: 0;
@@ -182,12 +182,9 @@
   box-shadow: var(--select-box-shadow-regular), var(--select-box-shadow-short);
 }
 
-.select-menu {
+.menu {
   display: block;
-  padding: 0;
-  margin: 0;
   overflow: auto;
-  max-height: 100%;
 }
 
 .before,

--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -42,7 +42,7 @@
   font-family: var(--select-font-regular);
 }
 
-.select[disabled] {
+:host([disabled]) {
   --select-color: var(--select-color-disabled);
   --select-color-focus: var(--select-color-disabled);
   --select-border-color: var(--select-border-color-disabled);
@@ -121,19 +121,18 @@
   outline-offset: 2px;
 }
 
-.select[disabled] .select-toggle,
-.select[disabled] .clear-button {
+.select-toggle[disabled],
+.select-toggle[disabled] .clear-button {
   cursor: unset;
 }
 
-.select[disabled] .label {
+.select-toggle[disabled] .label {
   color: var(--select-label-color);
 }
 
 .select-toggle.open .label,
 .select-toggle.filled .label,
-.select:not([disabled]) .select-toggle:focus .label,
-.select:not([disabled]) .select-toggle:active:not([disabled]) .label {
+.select-toggle:focus .label {
   color: var(--select-label-color);
   font-family: var(--select-font-black);
   font-size: 0.75rem;

--- a/src/components/select/stories/select.stories.js
+++ b/src/components/select/stories/select.stories.js
@@ -1,7 +1,10 @@
 import { html } from "lit"
 import { ifDefined } from "lit/directives/if-defined.js"
 
-import "../leu-select.js"
+import { LeuSelect } from "../leu-select.js"
+import "../../menu/leu-menu.js"
+import "../../menu/leu-menu-item.js"
+
 import { MUNICIPALITIES } from "../test/fixtures.js"
 
 export default {
@@ -37,7 +40,6 @@ function Template({
     <div style="margin-top: 50vh"></div>
     <leu-select
       class="dropdown"
-      .options=${options}
       label=${ifDefined(label)}
       .value=${ifDefined(value)}
       ?clearable=${clearable}
@@ -47,6 +49,20 @@ function Template({
     >
       ${before ? html`<div slot="before">${before}</div>` : ""}
       ${after ? html`<div slot="after">${after}</div>` : ""}
+      <leu-menu slot="menu">
+        ${options.map(
+          (option) => html`
+            <leu-menu-item
+              .value=${typeof option === "object" && option !== null
+                ? option.value
+                : option}
+              .label=${LeuSelect.getOptionLabel(option)}
+            >
+              ${LeuSelect.getOptionLabel(option)}
+            </leu-menu-item>
+          `
+        )}
+      </leu-menu>
     </leu-select>
     <div style="margin-top: 50vh"></div>
   `

--- a/src/components/select/stories/select.stories.js
+++ b/src/components/select/stories/select.stories.js
@@ -49,20 +49,18 @@ function Template({
     >
       ${before ? html`<div slot="before">${before}</div>` : ""}
       ${after ? html`<div slot="after">${after}</div>` : ""}
-      <leu-menu slot="menu">
-        ${options.map(
-          (option) => html`
-            <leu-menu-item
-              .value=${typeof option === "object" && option !== null
-                ? option.value
-                : option}
-              .label=${LeuSelect.getOptionLabel(option)}
-            >
-              ${LeuSelect.getOptionLabel(option)}
-            </leu-menu-item>
-          `
-        )}
-      </leu-menu>
+      ${options.map(
+        (option) => html`
+          <leu-menu-item
+            .value=${typeof option === "object" && option !== null
+              ? option.value
+              : option}
+            .label=${LeuSelect.getOptionLabel(option)}
+          >
+            ${LeuSelect.getOptionLabel(option)}
+          </leu-menu-item>
+        `
+      )}
     </leu-select>
     <div style="margin-top: 50vh"></div>
   `

--- a/src/components/select/test/select.test.js
+++ b/src/components/select/test/select.test.js
@@ -357,4 +357,51 @@ describe("LeuSelect", () => {
     const popup = el.shadowRoot.querySelector("leu-popup")
     expect(popup).to.not.have.attribute("active")
   })
+
+  it("focuses the filter input when the popup is opened", async () => {
+    const el = await defaultFixture({
+      options: MUNICIPALITIES,
+      label: "Gemeinde",
+      filterable: true,
+    })
+
+    const toggleButton = el.shadowRoot.querySelector(".select-toggle")
+    toggleButton.click()
+
+    await elementUpdated(el)
+
+    const filterInput = el.shadowRoot.querySelector(".select-search")
+    expect(filterInput).to.equal(el.shadowRoot.activeElement)
+  })
+
+  it("focuses the first menu item when the popup is opened", async () => {
+    const el = await defaultFixture({
+      options: MUNICIPALITIES,
+      label: "Gemeinde",
+    })
+
+    const toggleButton = el.shadowRoot.querySelector(".select-toggle")
+    toggleButton.click()
+
+    await elementUpdated(el)
+
+    const menuItems = el.querySelectorAll("leu-menu-item")
+    const firstMenuItem = menuItems[0]
+    expect(firstMenuItem).to.equal(document.activeElement)
+  })
+
+  it("closes the popup when the escape key is pressed", async () => {
+    const el = await defaultFixture({
+      options: MUNICIPALITIES,
+      label: "Gemeinde",
+    })
+
+    const toggleButton = el.shadowRoot.querySelector(".select-toggle")
+    toggleButton.click()
+
+    await sendKeys({ press: "Escape" })
+
+    const popup = el.shadowRoot.querySelector("leu-popup")
+    expect(popup.active).to.not.be.true
+  })
 })

--- a/src/components/select/test/select.test.js
+++ b/src/components/select/test/select.test.js
@@ -45,6 +45,17 @@ describe("LeuSelect", () => {
     await expect(el).shadowDom.to.be.accessible()
   })
 
+  it("passes the a11y audit when a value is set", async () => {
+    const el = await defaultFixture({
+      options: MUNICIPALITIES,
+      label: "Gemeinde",
+      value: "Affoltern am Albis",
+      clearable: true,
+    })
+
+    await expect(el).shadowDom.to.be.accessible()
+  })
+
   it("renders a label", async () => {
     const el = await defaultFixture({
       options: MUNICIPALITIES,


### PR DESCRIPTION
- Replace `options` property so that options can be defined without having to use the JavaScript API of the element.
- Fix A11Y Issues: Add correct aria attributes and fix focus handling
- Change Styles to match the styleguide
- Menu / MenuItems: A few adjustments on how focus and certain attributes/properties are being handled.
