### PR TITLE
Db/input value as number

### DIFF
--- a/src/components/chip/ChipGroup.js
+++ b/src/components/chip/ChipGroup.js
@@ -45,13 +45,20 @@ export class LeuChipGroup extends LeuElement {
   connectedCallback() {
     super.connectedCallback()
 
-    this.addEventListener("input", this.handleInput)
+    /**
+     * It is technically possible to add an event listener to the host element
+     * before it is connected to the dom. In that case the outside event listener would
+     * be called before the following event listener. But at this point multiple
+     * radio chips could be selected at the same time because `handleInput` hasn't been
+     * called yet. That's why we use the capture phase.
+     */
+    this.addEventListener("input", this.handleInput, { capture: true })
   }
 
   disconnectedCallback() {
     super.disconnectedCallback()
 
-    this.removeEventListener("input", this.handleInput)
+    this.removeEventListener("input", this.handleInput, { capture: true })
   }
 
   get value() {

--- a/src/components/chip/stories/chip-group.stories.js
+++ b/src/components/chip/stories/chip-group.stories.js
@@ -95,7 +95,8 @@ function DefaultTemplate(args) {
   const content = html`
     ${chips.map(
       (chip) => html`
-        <leu-chip-removable ?inverted=${args.inverted} label=${chip}>
+        <leu-chip-removable ?inverted=${args.inverted}>
+          ${chip}
         </leu-chip-removable>
       `
     )}
@@ -112,8 +113,8 @@ function SingleTemplate(args) {
           ?inverted=${args.inverted}
           variant=${SELECTABLE_VARIANTS.radio}
           value="chip-${chip}"
-          label=${chip}
         >
+          ${chip}
         </leu-chip-selectable>
       `
     )}
@@ -126,11 +127,8 @@ function MultipleTemplate(args) {
   const content = html`
     ${chips.map(
       (chip) => html`
-        <leu-chip-selectable
-          ?inverted=${args.inverted}
-          value="chip-${chip}"
-          label=${chip}
-        >
+        <leu-chip-selectable ?inverted=${args.inverted} value="chip-${chip}">
+          ${chip}
         </leu-chip-selectable>
       `
     )}
@@ -143,8 +141,7 @@ function LabeledTemplate(args) {
   const content = html`
     ${links.map(
       (chip) => html`
-        <leu-chip-link ?inverted=${args.inverted} label=${chip}>
-        </leu-chip-link>
+        <leu-chip-link ?inverted=${args.inverted}> ${chip} </leu-chip-link>
       `
     )}
   `

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -131,6 +131,7 @@ export class LeuInput extends LeuElement {
     this._validity = null
     this.validationMessages = {}
     this.novalidate = false
+    this.value = ""
 
     /** @internal */
     this._identifier = ""
@@ -140,6 +141,13 @@ export class LeuInput extends LeuElement {
      * @type {import("lit/directives/ref.js").Ref<HTMLInputElement>}
      */
     this._inputRef = createRef()
+  }
+
+  get valueAsNumber() {
+    if (this.value === "") {
+      return NaN
+    }
+    return Number(this.value)
   }
 
   /**

--- a/src/components/input/test/input.test.js
+++ b/src/components/input/test/input.test.js
@@ -449,4 +449,24 @@ describe("LeuInput", () => {
     expect(getClearButton()).to.be.null
     expect(getIcon()).to.be.null
   })
+
+  it("returns the value as a number when it is possible", async () => {
+    const el = await defaultFixture({ label: "Länge", type: "number" })
+
+    expect(el.valueAsNumber).to.be.NaN
+
+    el.focus()
+
+    await sendKeys({ type: "123" })
+
+    expect(el.valueAsNumber).to.equal(123)
+
+    el.type = "text"
+    await elementUpdated(el)
+
+    el.focus()
+    await sendKeys({ type: "abc" })
+
+    expect(el.valueAsNumber).to.be.NaN
+  })
 })

--- a/src/components/radio/RadioGroup.js
+++ b/src/components/radio/RadioGroup.js
@@ -43,13 +43,20 @@ export class LeuRadioGroup extends LeuElement {
   }
 
   addEventListeners() {
-    this.addEventListener("input", this.handleInput)
+    /**
+     * It is technically possible to add an event listener to the host element
+     * before it is connected to the dom. In that case the outside event listener would
+     * be called before the following event listener. But at this point multiple
+     * radio buttons could be selected at the same time because `handleInput` hasn't been
+     * called yet. That's why we use the capture phase.
+     */
+    this.addEventListener("input", this.handleInput, { capture: true })
     this.addEventListener("focusin", this.handleFocusIn)
     this.addEventListener("keydown", this.handleKeyDown)
   }
 
   removeEventListeners() {
-    this.removeEventListener("input", this.handleInput)
+    this.removeEventListener("input", this.handleInput, { capture: true })
     this.removeEventListener("focusin", this.handleFocusIn)
     this.removeEventListener("keydown", this.handleKeyDown)
   }
@@ -87,13 +94,9 @@ export class LeuRadioGroup extends LeuElement {
   }
 
   handleInput = (e) => {
-    if (e.target.checked) {
-      this.items
-        .filter((item) => item !== e.target)
-        .forEach((item) => {
-          item.checked = false // eslint-disable-line no-param-reassign
-        })
-    }
+    this.items.forEach((item) => {
+      item.checked = item === e.target // eslint-disable-line no-param-reassign
+    })
   }
 
   selectItem(selectingItem) {


### PR DESCRIPTION
This pull request address some issues that occured while using the components in observablehq.com Notebooks.

- Add `inputAsNumber` getter Method to the input Element so that Observable can retrieve the correct value.
- RadioGroup/ChipGroup: Handle input events and untoggling children elements in the event capture phase. So that input event listeners can be added to the element before the element is connected to the document and still can get the correct value.

