### PR TITLE
252 dropdown consistent height

### DIFF
--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -110,7 +110,7 @@ export class LeuButton extends LeuElement {
 
   renderExpandingIcon() {
     if (typeof this.expanded !== "undefined" && this.variant === "ghost") {
-      return html`<div class="icon-wrapper icon-wrapper--expanded">
+      return html`<div class="icon-expanded">
         <leu-icon name="angleDropDown" size="24"></leu-icon>
       </div>`
     }
@@ -170,9 +170,14 @@ export class LeuButton extends LeuElement {
         ?disabled=${this.disabled}
         type=${this.type}
       >
-        <slot name="before" class="icon-wrapper icon-wrapper--before"></slot>
+        <div class="icon-wrapper icon-wrapper--before">
+          <slot name="before" class="icon-wrapper__slot"></slot>
+        </div>
         <span class="content"><slot></slot></span>
-        <slot name="after" class="icon-wrapper icon-wrapper--after"></slot>
+        <div class="icon-wrapper icon-wrapper--after">
+          <slot name="after" class="icon-wrapper__slot"></slot>
+        </div>
+
         ${this.renderExpandingIcon()}
       </button>
     `

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -128,6 +128,7 @@ button.ghost {
   padding: 0 0.5rem;
   color: var(--leu-color-black-60);
   font-family: var(--leu-font-family-regular);
+  height: 2rem;
 }
 
 button.ghost:hover {

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -207,49 +207,82 @@ button.ghost.inverted:disabled {
   display: block;
 }
 
-.ghost.icon-before .icon-wrapper--before,
-.ghost.icon-after .icon-wrapper--after {
+.icon-wrapper {
+  display: none;
+}
+
+.icon-before .icon-wrapper--before,
+.icon-after .icon-wrapper--after {
   display: block;
-  padding: 0.5rem;
+}
+
+.ghost .icon-wrapper {
+  position: relative;
+  width: 2rem;
+  padding: 0 0.5rem;
+  --_bg: var(--leu-color-black-transp-10);
+  --_color: currentcolor;
+}
+
+.ghost .icon-wrapper__slot {
+  display: block;
+  position: relative;
+  z-index: 1;
+  color: var(--_color);
+}
+
+.ghost .icon-wrapper::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  left: 0;
+  top: -0.5rem;
+
+  width: 2rem;
+  aspect-ratio: 1;
   border-radius: 50%;
-  background: var(--leu-color-black-transp-10);
+  background: var(--_bg);
 }
 
-.ghost.active :is(.icon-wrapper--before, .icon-wrapper--after) {
-  background: var(--leu-color-black-100);
-  color: var(--leu-color-black-0);
+.ghost.active .icon-wrapper {
+  --_bg: var(--leu-color-black-100);
+  --_color: var(--leu-color-black-0);
 }
 
-.ghost:disabled :is(.icon-wrapper--before, .icon-wrapper--after) {
-  background: var(--leu-color-black-transp-5);
+.ghost:disabled .icon-wrapper {
+  --_bg: var(--leu-color-black-transp-5);
 }
 
 /* inverted */
 
-.ghost.inverted :is(.icon-wrapper--before, .icon-wrapper--after) {
-  background: var(--leu-color-black-transp-20);
+.ghost.inverted .icon-wrapper {
+  --_bg: var(--leu-color-black-transp-20);
 }
 
-.ghost.inverted:hover :is(.icon-wrapper--before, .icon-wrapper--after) {
-  background: var(--leu-color-black-transp-40);
-  color: var(--leu-color-black-0);
+.ghost.inverted:hover .icon-wrapper {
+  --_bg: var(--leu-color-black-transp-40);
+  --_color: var(--leu-color-black-0);
 }
 
-.ghost.inverted:disabled :is(.icon-wrapper--before, .icon-wrapper--after) {
-  background: var(--leu-color-black-transp-20);
-  color: var(--leu-color-white-transp-70);
+.ghost.inverted:disabled .icon-wrapper {
+  --_bg: var(--leu-color-black-transp-20);
+  --_color: var(--leu-color-white-transp-70);
 }
 
-.ghost.active.inverted :is(.icon-wrapper--before, .icon-wrapper--after) {
-  background: var(--leu-color-black-0);
-  color: var(--leu-color-black-100);
+.ghost.active.inverted .icon-wrapper {
+  --_bg: var(--leu-color-black-0);
+  --_color: var(--leu-color-black-100);
 }
 
 /* Expanded icon */
-.icon-wrapper--expanded {
+.icon-expanded leu-icon {
+  display: block;
+}
+
+.icon-expanded {
   transition: transform 0.1s ease;
 }
 
-:host([expanded="open"]) .icon-wrapper--expanded {
+:host([expanded="true"]) .icon-expanded {
   transform: rotate(180deg);
 }

--- a/src/components/button/stories/button.stories.js
+++ b/src/components/button/stories/button.stories.js
@@ -87,6 +87,7 @@ Regular.argTypes = {
   expanded: { control: "radio", options: BUTTON_EXPANDED_OPTIONS },
   disabled: { control: "boolean" },
   round: { control: "boolean" },
+  active: { control: "boolean" },
 }
 Regular.args = {
   content: "Click Mich...",

--- a/src/components/button/test/button.test.js
+++ b/src/components/button/test/button.test.js
@@ -58,7 +58,7 @@ describe("LeuButton", () => {
     const button = el.shadowRoot.querySelector("button")
 
     expect(button).dom.to.equal(
-      "<button><slot name='before'></slot><span><slot></slot></span><slot name='after'></slot></button>",
+      "<button><div><slot name='before'></slot></div><span><slot></slot></span><div><slot name='after'></slot></div></button>",
       { ignoreAttributes: ["class", "type"] }
     )
   })
@@ -73,7 +73,7 @@ describe("LeuButton", () => {
     const button = el.shadowRoot.querySelector("button")
 
     expect(button).dom.to.equal(
-      "<button aria-expanded='true'><slot name='before'></slot><span><slot></slot></span><slot name='after'></slot><div class='icon-wrapper icon-wrapper--expanded'><leu-icon name='angleDropDown' size='24'></leu-icon></div></button>",
+      "<button aria-expanded='true'><div><slot name='before'></slot></div><span><slot></slot></span><div><slot name='after'></slot></div><div class='icon-expanded'><leu-icon name='angleDropDown' size='24'></leu-icon></div></button>",
       { ignoreAttributes: ["class", "type"] }
     )
 
@@ -82,7 +82,7 @@ describe("LeuButton", () => {
     await elementUpdated(el)
 
     expect(button).dom.to.equal(
-      "<button class='primary regular' aria-expanded='true'><slot name='before'></slot><span><slot></slot></span><slot name='after'></slot></button>",
+      "<button class='primary regular' aria-expanded='true'><div><slot name='before'></slot></div><span><slot></slot></span><div><slot name='after'></slot></div></button>",
       { ignoreAttributes: ["class", "type"] }
     )
   })

--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -1,5 +1,6 @@
 :host {
   position: relative;
+  display: contents;
 }
 
 .content {

--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -1,3 +1,7 @@
+:host {
+  display: contents;
+}
+
 svg,
 .placeholder {
   display: block;

--- a/src/components/popup/popup.css
+++ b/src/components/popup/popup.css
@@ -3,6 +3,7 @@
   --popup-font-black: var(--leu-font-family-black);
 
   font-family: var(--popup-font-regular);
+  display: contents;
 }
 
 .popup {

--- a/src/styles/common-styles.css
+++ b/src/styles/common-styles.css
@@ -3,3 +3,12 @@
   box-sizing: border-box;
   font-feature-settings: var(--leu-t-font-feature-settings);
 }
+
+/**
+ * If a custom element sets the display property to any value
+ * it will not be hidden by the [hidden] attribute.
+ * That's why we need to specify this rule.
+ */
+:host([hidden]) {
+  display: none;
+}


### PR DESCRIPTION
The `leu-button` element is by default displayed as a inline-block element (like the native `button` element).
The ghost variant of the leu-button with an icon in the `before` (and *not* the `after`) slot creates a vertical space between the leu-button and its parent element. This is a normal behaviour for inline-block elements like an img. But there was no way to "fix" this with styles from outside the component.

I hate to say it, but i couldn't figure out why this issue exists only with the before slot. That's why i moved the background (gray circle) of the icon to the before pseudo element that is absolutely positioned.