### PR TITLE
Hide accordion content when it is in a closed state

### DIFF
--- a/src/components/accordion/Accordion.js
+++ b/src/components/accordion/Accordion.js
@@ -49,7 +49,7 @@ export class LeuAccordion extends LeuElement {
   _getHeadingTag() {
     let level = 2
     if (this.headingLevel > 0 && this.headingLevel < 7) {
-      level = this.headingLevel
+      level = Math.floor(this.headingLevel)
     }
 
     return `h${level}`

--- a/src/components/accordion/accordion.css
+++ b/src/components/accordion/accordion.css
@@ -114,6 +114,8 @@
 
 .contentwrapper[hidden] {
   grid-template-rows: 0fr;
+  opacity: 0;
+  visibility: hidden;
 }
 
 slot[name="content"] {

--- a/src/components/accordion/accordion.css
+++ b/src/components/accordion/accordion.css
@@ -27,7 +27,7 @@
   width: 100%;
   background: none;
   padding: 1rem 0;
-  margin: none;
+  margin: 0;
   cursor: pointer;
 
   border: none;
@@ -132,7 +132,6 @@ slot[name="content"] {
 }
 
 .divider {
-
   width: 100%;
   height: 1px;
   margin: 0;
@@ -140,7 +139,9 @@ slot[name="content"] {
   border: none;
   background-color: var(--divider-color);
 
-  transition: transform var(--transition), background-color var(--transition);
+  transition:
+    transform var(--transition),
+    background-color var(--transition);
 }
 
 :host(:not([open])) .heading:is(:hover, :focus-visible) ~ .divider {

--- a/src/components/accordion/stories/accordion.stories.js
+++ b/src/components/accordion/stories/accordion.stories.js
@@ -7,7 +7,7 @@ export default {
   title: "Components/Accordion",
   component: "leu-accordion",
   argTypes: {
-    headingLevel: {
+    "heading-level": {
       control: "select",
       options: [1, 2, 3, 4, 5, 6],
     },
@@ -27,9 +27,10 @@ export default {
 
 function Template(args) {
   return html` <leu-accordion
-    heading-level=${ifDefined(args.headingLevel)}
+    heading-level=${ifDefined(args["heading-level"])}
     label=${ifDefined(args.label)}
-    label-prefix=${ifDefined(args.labelPrefix)}
+    label-prefix=${ifDefined(args["label-prefix"])}
+    ?open=${args.open}
   >
     <div slot="content">${args.content}</div>
   </leu-accordion>`
@@ -37,7 +38,7 @@ function Template(args) {
 
 export const Regular = Template.bind({})
 Regular.args = {
-  headingLevel: 2,
+  "heading-level": 2,
   label:
     "Akkordeontitel der lang und noch länger werden kann und dann umbricht",
   content: `Regular Interessierte können ab sofort die Genauigkeit ihrer Smartphones
@@ -55,5 +56,5 @@ Regular.args = {
 export const Prefix = Template.bind({})
 Prefix.args = {
   ...Regular.args,
-  labelPrefix: "01",
+  "label-prefix": "01",
 }


### PR DESCRIPTION
"Properly" hide the content of the accordion, when the component is closed to ensure it won't be reachable with the browser search functionality or with screenreaders.

I also made sure that the heading level is an integer.