### PR TITLE
Select: Keep the popup open when focus leaves the element

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -356,18 +356,6 @@ export class LeuSelect extends LeuElement {
     }
   }
 
-  /**
-   * Close the dropdown if the focus moves outside the component.
-   */
-  _handlePopupFocusOut(event) {
-    if (
-      !this.contains(event.relatedTarget) &&
-      !this.shadowRoot.contains(event.relatedTarget)
-    ) {
-      this._closeDropdown()
-    }
-  }
-
   _renderFilterInput() {
     if (this.filterable) {
       return html` <leu-input
@@ -467,11 +455,7 @@ export class LeuSelect extends LeuElement {
           autoSizePadding="8"
         >
           ${this._renderToggleButton()}
-          <div
-            id="select-popup"
-            class="select-menu-container"
-            @focusout=${this._handlePopupFocusOut}
-          >
+          <div id="select-popup" class="select-menu-container">
             <slot name="before" class="before"></slot>
             ${this._renderFilterInput()}
             <leu-menu

--- a/src/components/select/stories/select.stories.js
+++ b/src/components/select/stories/select.stories.js
@@ -68,7 +68,7 @@ function Template({
 
 function TemplateSlots(args) {
   const before = html`<div>before</div>`
-  const after = html`<div>after <input type="text"></input></div>`
+  const after = html`<div>after <input type="text" /></div>`
 
   return Template({ ...args, before, after })
 }


### PR DESCRIPTION
Let's keep the element open when focus leaves the element for the moment.

Related Issue:
#272 

The focusout event behaviour of safari is different than in FF or in chrome.
If an interactive element like leu-chip-selectable is placed inside the before slot and receives focus with a click, the focusout event will then force the popup to close.

I don't have any solution for this at the moment.

I opened another issue that should tackle the issue of focus handling
#280 
