### PR TITLE
fix(file-input): format >1000MB as GB

### DIFF
--- a/src/components/file-input/FileInput.ts
+++ b/src/components/file-input/FileInput.ts
@@ -145,16 +145,35 @@ export class LeuFileInput extends FormAssociatedMixin(LeuElement) {
     )
   }
 
+  /**
+   * This implementation Uses base-10 (decimal) units:
+   * 1 KB = 1_000 bytes
+   * 1 MB = 1_000_000 bytes
+   * 1 GB = 1_000_000_000 bytes
+   *
+   * To switch to base-2 (binary), use the following implementation:
+   * // const KB = 1024
+   * // const MB = 1024 * 1024
+   * // const GB = 1024 * 1024 * 1024
+   */
   protected static formatFileSize(size: number) {
-    if (size < 1e3) {
-      return html`${size}&nbsp;bytes`
+    const KB = 1e3
+    const MB = 1e6
+    const GB = 1e9
+
+    if (size >= GB) {
+      return html`${(size / GB).toFixed(1)}&nbsp;GB`
     }
 
-    if (size >= 1e3 && size < 1e6) {
-      return html`${(size / 1e3).toFixed(1)}&nbsp;KB`
+    if (size >= MB) {
+      return html`${(size / MB).toFixed(1)}&nbsp;MB`
     }
 
-    return html`${(size / 1e6).toFixed(1)}&nbsp;MB`
+    if (size >= KB) {
+      return html`${(size / KB).toFixed(1)}&nbsp;KB`
+    }
+
+    return html`${size}&nbsp;bytes`
   }
 
   protected handleDragEnter = (event: DragEvent) => {


### PR DESCRIPTION
Neu: `Grösse: 10.2 GB`

<img width="1754" height="868" alt="image" src="https://github.com/user-attachments/assets/59cb190f-0faa-46f8-af7f-dd96ffe50634" />


Vorher: `Grösse: 10219.1 MB`

<img width="1751" height="919" alt="image" src="https://github.com/user-attachments/assets/296a10fc-51d8-4659-9761-95961ae9648d" />
