### PR TITLE
button: add href and remove fluid property

### DIFF
--- a/src/components/button/Button.ts
+++ b/src/components/button/Button.ts
@@ -1,4 +1,5 @@
-import { html, nothing } from "lit"
+import { nothing } from "lit"
+import { html, literal } from "lit/static-html.js"
 import { classMap } from "lit/directives/class-map.js"
 import { ifDefined } from "lit/directives/if-defined.js"
 import { property, query } from "lit/decorators.js"
@@ -58,19 +59,28 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
   variant: "primary" | "secondary" | "ghost" = "primary"
 
   /**
-   * The `type` of the underlying button element.
+   * The `type` of the underlying button element. Ignored when `href` is set.
    */
   @property({ type: String, reflect: true })
   type: "button" | "submit" | "reset" = "button"
 
   /**
-   * The `role` of the underlying button element.
+   * The `role` of the underlying button element. Ignored when `href` is set.
    */
   @property({ type: String, reflect: true })
   componentRole?: string
 
   /**
-   * Whether the button is disabled or not.
+   * If set, renders the button as an <a> element instead of a <button> with the provided href.
+   */
+  @property({ type: String, reflect: true })
+  href: string
+
+  /** Tells the browser where to display the linked URL. Only used when `href` is set. */
+  @property() target: "_blank" | "_parent" | "_self" | "_top"
+
+  /**
+   * Whether the button is disabled or not. Ignored when `href` is set.
    * @type {boolean}
    */
   @property({ type: Boolean, reflect: true })
@@ -105,12 +115,6 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
    */
   @property({ type: String, reflect: true })
   expanded?: "true" | "false"
-
-  /**
-   * Alters the shape of the button to be full width of its parent container
-   */
-  @property({ type: Boolean, reflect: true })
-  fluid: boolean = false
 
   /**
    * Replaces the content with a spinner
@@ -227,7 +231,10 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
     const hasIconDefault = Boolean(this.querySelector("leu-icon"))
     const hasIconBefore = this.hasSlotController.test("before")
     const hasIconAfter = this.hasSlotController.test("after")
+    const isLink = Boolean(this.href)
     const aria = this.getAriaAttributes()
+
+    const tag = isLink ? literal`a` : literal`button`
 
     const cssClasses = {
       button: true,
@@ -237,24 +244,27 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
       "button--round": this.round,
       "button--active": this.active,
       "button--inverted": this.inverted,
-      "button--fluid": this.fluid,
       "button--loading": this.loading,
       "button--disabled": this.disabled,
       [`button--${this.variant}`]: true,
       [`button--${this.size}`]: true,
     }
 
+    /* The eslint rules don't recognize html import from lit/static-html.js */
+    /* eslint-disable lit/binding-positions, lit/no-invalid-html */
     return html`
-      <button
+      <${tag}
         @click=${this.handleClick}
         aria-label=${ifDefined(aria.label)}
         aria-selected=${ifDefined(aria.selected)}
         aria-checked=${ifDefined(aria.checked)}
         aria-expanded=${ifDefined(this.expanded)}
-        role=${ifDefined(aria.role)}
+        role=${ifDefined(isLink ? undefined : aria.role)}
+        href=${ifDefined(this.href)}
+        target=${ifDefined(isLink ? this.target : undefined)}
         class=${classMap(cssClasses)}
-        ?disabled=${this.disabled || this.loading}
-        type=${this.type}
+        ?disabled=${(this.disabled && !isLink) || this.loading}
+        type=${ifDefined(isLink ? undefined : this.type)}
       >
         <div class="icon-wrapper icon-wrapper--before">
           <slot name="before" class="icon-wrapper__slot"></slot>
@@ -263,11 +273,14 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
         <div class="icon-wrapper icon-wrapper--after">
           <slot name="after" class="icon-wrapper__slot"></slot>
         </div>
-        ${this.loading
-          ? html`<leu-spinner class="spinner"></leu-spinner>`
-          : nothing}
+        ${
+          this.loading
+            ? html`<leu-spinner class="spinner"></leu-spinner>`
+            : nothing
+        }
         ${this.renderExpandingIcon()}
-      </button>
+      </${tag}>
     `
+    /* eslint-enable lit/binding-positions, lit/no-invalid-html */
   }
 }

--- a/src/components/button/Button.ts
+++ b/src/components/button/Button.ts
@@ -123,7 +123,7 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
   loading: boolean = false
 
   @query(".button")
-  private button!: HTMLButtonElement
+  private button!: HTMLButtonElement | HTMLAnchorElement
 
   private renderExpandingIcon() {
     if (typeof this.expanded !== "undefined" && this.variant === "ghost") {
@@ -254,7 +254,7 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
     /* eslint-disable lit/binding-positions, lit/no-invalid-html */
     return html`
       <${tag}
-        @click=${this.handleClick}
+        @click=${!isLink ? this.handleClick : undefined}
         aria-label=${ifDefined(aria.label)}
         aria-selected=${ifDefined(aria.selected)}
         aria-checked=${ifDefined(aria.checked)}

--- a/src/components/button/Button.ts
+++ b/src/components/button/Button.ts
@@ -231,17 +231,19 @@ export class LeuButton extends FormAssociatedMixin(LeuElement) {
 
     const cssClasses = {
       button: true,
-      "icon-only": hasIconDefault && !hasTextContent,
-      "icon-before": hasIconBefore,
-      "icon-after": hasIconAfter,
-      round: this.round,
-      active: this.active,
-      disabled: this.disabled,
-      inverted: this.inverted,
-      loading: this.loading,
-      [this.variant]: true,
-      [this.size]: true,
+      "button--icon-only": hasIconDefault && !hasTextContent,
+      "button--icon-before": hasIconBefore,
+      "button--icon-after": hasIconAfter,
+      "button--round": this.round,
+      "button--active": this.active,
+      "button--inverted": this.inverted,
+      "button--fluid": this.fluid,
+      "button--loading": this.loading,
+      "button--disabled": this.disabled,
+      [`button--${this.variant}`]: true,
+      [`button--${this.size}`]: true,
     }
+
     return html`
       <button
         @click=${this.handleClick}

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -5,9 +5,8 @@
 /*
  * @todo : Disable hover styles for loading state
  */
-button {
+.button {
   position: relative;
-
   font-family: var(--leu-font-family-black);
   text-align: center;
   appearance: none;
@@ -29,28 +28,28 @@ button {
   white-space: nowrap;
 }
 
-button.round {
+.button--round {
   border-radius: 50%;
 }
 
-button.disabled {
+.button--disabled {
   cursor: not-allowed;
 }
 
-button.loading {
+.button--loading {
   cursor: wait;
 }
 
-button:focus-visible {
+.button:focus-visible {
   outline: 2px solid var(--leu-color-func-cyan);
   outline-offset: 2px;
 }
 
-button.inverted:focus-visible {
+.button--inverted:focus-visible {
   outline: 2px solid var(--leu-color-black-0);
 }
 
-:host([fluid]) button {
+.button--fluid {
   width: 100%;
   justify-content: center;
 }
@@ -60,18 +59,18 @@ button.loading :where(.content, .icon-wrapper) {
 }
 
 /* size - regular */
-button.regular {
+.button--regular {
   padding: 12px 24px;
   font-size: 16px;
   line-height: 24px;
 }
 
-button.regular.icon-only {
+.button--regular.button--icon-only {
   padding: 12px;
 }
 
 /* size - small */
-button.small {
+.button--small {
   padding: 6px 24px;
   font-size: 14px;
   line-height: 20px;
@@ -79,62 +78,62 @@ button.small {
   --leu-icon-size: 1rem;
 }
 
-button.small.icon-only {
+.button--small.button--icon-only {
   padding: 8px;
 }
 
 /* primary */
-button.primary {
+.button--primary {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-100);
 }
 
-button.primary:hover {
+.button--primary:hover {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-transp-80);
 }
 
-button.primary.active {
+.button--primary.button--active {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-100);
 }
 
-button.primary.active:hover {
+.button--primary.button--active:hover {
   background: var(--leu-color-black-transp-80);
 }
 
-button.primary.disabled {
+.button--primary.button--disabled {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-transp-20);
 }
 
 /* secondary */
-button.secondary {
+.button--secondary {
   color: var(--leu-color-black-transp-60);
   background: var(--leu-color-black-transp-10);
 }
 
-button.secondary:hover {
+.button--secondary:hover {
   color: var(--leu-color-black-100);
   background: var(--leu-color-black-transp-20);
 }
 
-button.secondary.active {
+.button--secondary.button--active {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-100);
 }
 
-button.secondary.active:hover {
+.button--secondary.button--active:hover {
   background: var(--leu-color-black-transp-80);
 }
 
-button.secondary.disabled {
+.button--secondary.button--disabled {
   color: var(--leu-color-black-transp-20);
   background: var(--leu-color-black-transp-5);
 }
 
 /* ghost */
-button.ghost {
+.button--ghost {
   --leu-icon-size: 1rem;
 
   background: transparent;
@@ -144,74 +143,74 @@ button.ghost {
   height: 2rem;
 }
 
-button.ghost:hover {
+.button--ghost:hover {
   color: var(--leu-color-black-100);
 }
 
-button.ghost.active {
+.button--ghost.button--active {
   color: var(--leu-color-black-100);
 }
 
-button.ghost.disabled {
+.button--ghost.button--disabled {
   color: var(--leu-color-black-20);
 }
 
 /* primary + inverted */
-button.primary.inverted {
+.button--primary.button--inverted {
   color: var(--leu-color-black-100);
   background: var(--leu-color-black-0);
 }
 
-button.primary.inverted:hover {
+.button--primary.button--inverted:hover {
   color: var(--leu-color-black-100);
   background: var(--leu-color-white-transp-70);
 }
 
-button.primary.inverted.active {
+.button--primary.button--inverted.button--active {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-100);
 }
 
-button.primary.inverted.disabled {
+.button--primary.button--inverted.button--disabled {
   color: var(--leu-color-black-40);
   background: var(--leu-color-white-transp-70);
 }
 
 /* secondary + inverted */
-button.secondary.inverted {
+.button--secondary.button--inverted {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-transp-20);
 }
 
-button.secondary.inverted:hover {
+.button--secondary.button--inverted:hover {
   color: var(--leu-color-black-0);
   background: var(--leu-color-black-transp-40);
 }
 
-button.secondary.inverted.active {
+.button--secondary.button--inverted.button--active {
   color: var(--leu-color-black-100);
   background: var(--leu-color-black-0);
 }
 
-button.secondary.inverted.disabled {
+.button--secondary.button--inverted.button--disabled {
   color: var(--leu-color-white-transp-70);
   background: var(--leu-color-black-transp-10);
 }
 
 /* ghost + inverted */
-button.ghost.inverted {
+.button--ghost.button--inverted {
   color: var(--leu-color-black-0);
 }
 
-button.ghost.inverted:hover {
+.button--ghost.button--inverted:hover {
   color: var(--leu-color-white-transp-70);
 }
 
-button.ghost.inverted.active {
+.button--ghost.button--inverted.button--active {
   color: var(--leu-color-black-0);
 }
 
-button.ghost.inverted.disabled {
+.button--ghost.button--inverted.button--disabled {
   color: var(--leu-color-black-20);
 }
 
@@ -224,12 +223,12 @@ button.ghost.inverted.disabled {
   display: none;
 }
 
-.icon-before .icon-wrapper--before,
-.icon-after .icon-wrapper--after {
+.button--icon-before .icon-wrapper--before,
+.button--icon-after .icon-wrapper--after {
   display: block;
 }
 
-.ghost .icon-wrapper {
+.button--ghost .icon-wrapper {
   position: relative;
   width: 2rem;
   padding: 0 0.5rem;
@@ -237,14 +236,14 @@ button.ghost.inverted.disabled {
   --_color: currentcolor;
 }
 
-.ghost .icon-wrapper__slot {
+.button--ghost .icon-wrapper__slot {
   display: block;
   position: relative;
   z-index: 1;
   color: var(--_color);
 }
 
-.ghost .icon-wrapper::before {
+.button--ghost .icon-wrapper::before {
   content: "";
   position: absolute;
   z-index: 0;
@@ -257,32 +256,32 @@ button.ghost.inverted.disabled {
   background: var(--_bg);
 }
 
-.ghost.active .icon-wrapper {
+.button--ghost.button--active .icon-wrapper {
   --_bg: var(--leu-color-black-100);
   --_color: var(--leu-color-black-0);
 }
 
-.ghost.disabled .icon-wrapper {
+.button--ghost.button--disabled .icon-wrapper {
   --_bg: var(--leu-color-black-transp-5);
 }
 
 /* inverted */
 
-.ghost.inverted .icon-wrapper {
+.button--ghost.button--inverted .icon-wrapper {
   --_bg: var(--leu-color-black-transp-20);
 }
 
-.ghost.inverted:hover .icon-wrapper {
+.button--ghost.button--inverted:hover .icon-wrapper {
   --_bg: var(--leu-color-black-transp-40);
   --_color: var(--leu-color-black-0);
 }
 
-.ghost.inverted.disabled .icon-wrapper {
+.button--ghost.button--inverted.button--disabled .icon-wrapper {
   --_bg: var(--leu-color-black-transp-20);
   --_color: var(--leu-color-white-transp-70);
 }
 
-.ghost.active.inverted .icon-wrapper {
+.button--ghost.button--active.button--inverted .icon-wrapper {
   --_bg: var(--leu-color-black-0);
   --_color: var(--leu-color-black-100);
 }

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -9,16 +9,18 @@
   position: relative;
   font-family: var(--leu-font-family-black);
   text-align: center;
+  text-decoration: none;
   appearance: none;
   transition: background 0.1s ease;
   cursor: pointer;
   border: none;
   border-radius: 2px;
 
-  max-width: 100%;
-  display: flex;
+  display: inline-flex;
+  justify-content: center;
   align-items: center;
   column-gap: 8px;
+  width: 100%;
 }
 
 .content {
@@ -49,9 +51,9 @@
   outline: 2px solid var(--leu-color-black-0);
 }
 
-.button--fluid {
-  width: 100%;
-  justify-content: center;
+.button--icon-only {
+  aspect-ratio: 1;
+  width: unset;
 }
 
 button.loading :where(.content, .icon-wrapper) {

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -56,7 +56,7 @@
   width: unset;
 }
 
-button.loading :where(.content, .icon-wrapper) {
+.button--loading :where(.content, .icon-wrapper) {
   visibility: hidden;
 }
 

--- a/src/components/button/stories/button.stories.ts
+++ b/src/components/button/stories/button.stories.ts
@@ -37,13 +37,14 @@ function Template(args = {}) {
         variant=${ifDefined(args.variant)}
         type=${ifDefined(args.type)}
         expanded=${ifDefined(args.expanded)}
+        href=${ifDefined(args.href)}
+        target=${ifDefined(args.target)}
         ?round=${args.round}
         ?active=${args.active}
         ?inverted=${args.inverted}
         ?disabled=${args.disabled}
         ?loading=${args.loading}
-        ?fluid=${args.fluid}
-        @click=${copyContent}
+        @click=${args.href ? undefined : copyContent}
       >
         ${args.icon
           ? html`<leu-icon
@@ -55,7 +56,9 @@ function Template(args = {}) {
       </leu-button>
     </div>
     <br />
-    <p>Click the button to copy the code to the clipboard</p>
+    ${args.href
+      ? nothing
+      : html`<p>Click the button to copy the code to the clipboard</p>`}
   `
 
   return html`
@@ -90,7 +93,7 @@ Regular.argTypes = {
   round: { control: "boolean" },
   active: { control: "boolean" },
   loading: { control: "boolean" },
-  fluid: { control: "boolean" },
+  href: { control: "text" },
 }
 Regular.args = {
   content: "Click Mich...",
@@ -98,13 +101,23 @@ Regular.args = {
   disabled: false,
   active: false,
   inverted: false,
-  fluid: false,
 
   icon: null,
   iconPosition: "before",
   size: null,
   variant: null,
   type: null,
+}
+
+export const Link = Template.bind({})
+Link.args = {
+  content: "Zu den Daten",
+  icon: "link",
+  iconPosition: "before",
+  href: "https://datenkatalog.statistik.zh.ch/",
+  target: "_blank",
+  variant: "ghost",
+  size: "regular",
 }
 
 const items = [
@@ -304,6 +317,7 @@ function TemplateOverview() {
       .table {
         display: grid;
         align-items: center;
+        justify-items: start;
         grid-template-columns: auto auto auto;
         gap: 10px;
         padding: 10px;
@@ -330,7 +344,6 @@ function TemplateOverview() {
                         size=${ifDefined(size.size)}
                         variant=${ifDefined(group.variant)}
                         expanded=${ifDefined(item.expanded)}
-                        ?round=${item.round}
                         ?active=${item.active}
                         ?disabled=${item.disabled}
                         ?inverted=${group.inverted}

--- a/src/components/button/stories/button.stories.ts
+++ b/src/components/button/stories/button.stories.ts
@@ -42,6 +42,7 @@ function Template(args = {}) {
         ?inverted=${args.inverted}
         ?disabled=${args.disabled}
         ?loading=${args.loading}
+        ?fluid=${args.fluid}
         @click=${copyContent}
       >
         ${args.icon
@@ -89,6 +90,7 @@ Regular.argTypes = {
   round: { control: "boolean" },
   active: { control: "boolean" },
   loading: { control: "boolean" },
+  fluid: { control: "boolean" },
 }
 Regular.args = {
   content: "Click Mich...",
@@ -96,6 +98,7 @@ Regular.args = {
   disabled: false,
   active: false,
   inverted: false,
+  fluid: false,
 
   icon: null,
   iconPosition: "before",

--- a/src/components/button/stories/button.stories.ts
+++ b/src/components/button/stories/button.stories.ts
@@ -29,7 +29,7 @@ export default {
 }
 
 function Template(args = {}) {
-  const component = html`
+  return html`
     <div data-root>
       <leu-button
         content=${ifDefined(args.content)}
@@ -54,25 +54,6 @@ function Template(args = {}) {
           : nothing}
         ${args.content}
       </leu-button>
-    </div>
-    <br />
-    ${args.href
-      ? nothing
-      : html`<p>Click the button to copy the code to the clipboard</p>`}
-  `
-
-  return html`
-    <style>
-      * {
-        font-family: Helvetica;
-      }
-    </style>
-    <div
-      style="${args.inverted
-        ? "background:var(--leu-color-accent-blue); color: var(--leu-color-white-transp-90);"
-        : ""}padding:40px;"
-    >
-      ${component}
     </div>
   `
 }

--- a/src/components/button/test/button.test.ts
+++ b/src/components/button/test/button.test.ts
@@ -192,6 +192,42 @@ describe("LeuButton", () => {
     expect(clicked).to.be.false
   })
 
+  it("renders as an anchor when href is set", async () => {
+    const el = await fixture(
+      html` <leu-button
+        href="https://datenkatalog.statistik.zh.ch/"
+        target="_blank"
+        >Zu den Daten <leu-icon name="link" slot="before"></leu-icon
+      ></leu-button>`,
+    )
+
+    const anchor = el.shadowRoot.querySelector("a")
+
+    expect(anchor).to.exist
+    expect(anchor).to.have.attribute(
+      "href",
+      "https://datenkatalog.statistik.zh.ch/",
+    )
+    expect(anchor).to.have.attribute("target", "_blank")
+  })
+
+  it("does not set disabled or type attribute on anchor", async () => {
+    const el = await fixture(
+      html` <leu-button
+        href="https://datenkatalog.statistik.zh.ch/"
+        disabled
+        type="submit"
+        >Zu den Daten <leu-icon name="link" slot="before"></leu-icon
+      ></leu-button>`,
+    )
+
+    const anchor = el.shadowRoot.querySelector("a")
+
+    expect(anchor).to.exist
+    expect(anchor).to.not.have.attribute("disabled")
+    expect(anchor).to.not.have.attribute("type")
+  })
+
   describe("form association", () => {
     it("submits the form when type is submit", async () => {
       const form = await fixture<HTMLFormElement>(html`

--- a/src/components/button/test/button.test.ts
+++ b/src/components/button/test/button.test.ts
@@ -32,6 +32,16 @@ describe("LeuButton", () => {
     await expect(el).shadowDom.to.be.accessible()
   })
 
+  it("passes the a11y audit when rendered as link", async () => {
+    const el = await fixture(
+      html` <leu-button href="https://datenkatalog.statistik.zh.ch/"
+        >Link</leu-button
+      >`,
+    )
+
+    await expect(el).shadowDom.to.be.accessible()
+  })
+
   it("renders the label", async () => {
     const el = await fixture(html` <leu-button>Sichern</leu-button>`)
 

--- a/src/components/select/Select.ts
+++ b/src/components/select/Select.ts
@@ -472,7 +472,6 @@ export class LeuSelect extends FormAssociatedMixin(LeuElement) {
             type="button"
             class="apply-button"
             @click=${this._closeDropdown}
-            fluid
             >Anwenden</leu-button
           >
         </div>


### PR DESCRIPTION
- Remove `fluid` property. The width of the element can now entirely be controlled with css from the outside.
- Add `href` property so that the button is rendered as an anchor element