### PR TITLE
fix (FileInput): resolve file input not able to add same file after deletion #322

### DIFF
--- a/src/components/file-input/FileInput.ts
+++ b/src/components/file-input/FileInput.ts
@@ -286,7 +286,10 @@ export class LeuFileInput extends FormAssociatedMixin(LeuElement) {
           <leu-button
             variant="secondary"
             ?disabled=${this.disabled}
-            @click=${() => this.input.click()}
+            @click=${() => {
+              this.input.value = ""
+              this.input.click()
+            }}
           >
             Datei auswählen
             <leu-icon name="upload" slot="after"></leu-icon>

--- a/src/components/file-input/FileInput.ts
+++ b/src/components/file-input/FileInput.ts
@@ -95,6 +95,7 @@ export class LeuFileInput extends FormAssociatedMixin(LeuElement) {
   private handleChange(event: Event & { target: HTMLInputElement }) {
     const customEvent = new CustomEvent(event.type, event)
     this.dispatchEvent(customEvent)
+    this.input.value = ""
   }
 
   public formResetCallback() {
@@ -287,7 +288,6 @@ export class LeuFileInput extends FormAssociatedMixin(LeuElement) {
             variant="secondary"
             ?disabled=${this.disabled}
             @click=${() => {
-              this.input.value = ""
               this.input.click()
             }}
           >

--- a/src/components/file-input/test/file-input.test.ts
+++ b/src/components/file-input/test/file-input.test.ts
@@ -35,4 +35,42 @@ describe("LeuFileInput", () => {
     expect(fileInput.validity.valueMissing).to.be.true
     expect(form.checkValidity()).to.be.false
   })
+
+  it("should successfully add the same file after it has been deleted", async () => {
+    const el = await defaultFixture()
+    const file = new File(["Testdatei"], "datei.txt")
+
+    const triggerFileSelection = (file: File) => {
+      const dt = new DataTransfer()
+      dt.items.add(file)
+      el.input.files = dt.files
+
+      el.input.dispatchEvent(
+        new Event("input", { bubbles: true, composed: true }),
+      )
+      el.input.dispatchEvent(
+        new Event("change", { bubbles: true, composed: true }),
+      )
+    }
+
+    triggerFileSelection(file)
+    await el.updateComplete
+
+    expect(el.files.length).to.equal(1)
+    expect(el.files[0].name).to.equal("datei.txt")
+
+    const deleteButton =
+      el.shadowRoot!.querySelector<HTMLElement>(".file__button")
+    deleteButton.click()
+    await el.updateComplete
+
+    expect(el.files.length).to.equal(0)
+    expect(el.input.value).to.equal("")
+
+    triggerFileSelection(file)
+    await el.updateComplete
+
+    expect(el.files.length).to.equal(1)
+    expect(el.files[0].name).to.equal("datei.txt")
+  })
 })


### PR DESCRIPTION
## Description
fixes the issue where selecting the same file after deletion again would not trigger handleInput. 

By clearing the hidden file input value when clicked, the browser sees the next selection as a "new" change, even if it is the same file. This ensures that the component triggers the function.

Closes #322

## Testing
- Verified in Storybook that the same file can be selected multiple times.
- Ensured the change event is fired correctly on each selection.