### PR TITLE
Range: input to custom slider refactoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,14 @@ it.only("should render correctly", () => {
 
 **Important:** Only run tests for the component being modified, not the full suite, unless validating a cross-cutting change.
 
+**Testing mouse and keyboard interaction**
+
+Use the following commands to simulate user interactions in tests:
+
+```ts
+import { resetMouse, sendKeys, sendMouse } from "@web/test-runner-commands"
+```
+
 ## Component Development
 
 A new component can be scaffolded using the provided script:

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -270,13 +270,17 @@ export class LeuRange extends LeuElement {
     switch (key) {
       case "ArrowLeft":
       case "ArrowDown":
-      case "PageDown":
         nextValue = currentValue - this.step
+        break
+      case "PageDown":
+        nextValue = currentValue - this.step * 10
         break
       case "ArrowRight":
       case "ArrowUp":
-      case "PageUp":
         nextValue = currentValue + this.step
+        break
+      case "PageUp":
+        nextValue = currentValue + this.step * 10
         break
       case "Home":
         nextValue = this.min

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -212,7 +212,12 @@ export class LeuRange extends LeuElement {
   }
 
   protected clampAndRoundValue(value: number) {
-    const clampedValue = clamp(value, this.min, this.max)
+    // The `max` value could technically be unreachable if the range between `min` and `max` is not a multiple of `step`.
+    // To ensure that new value is in every case a multiple of `step` away from `min`,
+    // we need to round the `max` value down to the nearest multiple of `step`.
+    const roundedMax = this.max - ((this.max - this.min) % this.step)
+
+    const clampedValue = clamp(value, this.min, roundedMax)
     const roundedValue =
       Math.round((clampedValue - this.min) / this.step) * this.step + this.min
 

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -173,7 +173,11 @@ export class LeuRange extends LeuElement {
   }
 
   get valueAsArray(): InternalRangeValue {
-    return this._value.slice() as InternalRangeValue
+    if (this.multiple) {
+      return [this.valueLow, this.valueHigh]
+    } else {
+      return [this._value[0]]
+    }
   }
 
   get valueLow(): number {
@@ -355,7 +359,7 @@ export class LeuRange extends LeuElement {
       return
     }
 
-    const nextValueArray = this.valueAsArray
+    const nextValueArray = this._value.slice()
     nextValueArray[index] = nextValue
 
     this.value = nextValueArray
@@ -432,9 +436,7 @@ export class LeuRange extends LeuElement {
 
   protected getNormalizedRange() {
     if (this.multiple) {
-      return this.valueAsArray
-        .map((value) => this.getNormalizedValue(value))
-        .sort((a, b) => a - b)
+      return this.valueAsArray.map((value) => this.getNormalizedValue(value))
     }
 
     return [0, this.getNormalizedValue(this.valueAsArray[0])]
@@ -468,9 +470,9 @@ export class LeuRange extends LeuElement {
   }
 
   render() {
-    const inputs = this.multiple ? ["base", "ghost"] : ["base"]
+    const inputs = this.multiple ? ["low", "high"] : ["single"]
 
-    const { multiple, disabled, label, valueAsArray, hideLabel } = this
+    const { multiple, disabled, label, _value, hideLabel } = this
     const normalizedRange = this.getNormalizedRange()
 
     return html`
@@ -487,8 +489,16 @@ export class LeuRange extends LeuElement {
         ${multiple
           ? html`
               <leu-visually-hidden>
-                <span id="label-0">${RANGE_LABELS[0]}</span>
-                <span id="label-1">${RANGE_LABELS[1]}</span>
+                <span id="label-0"
+                  >${_value[0] < _value[1]!
+                    ? RANGE_LABELS[0]
+                    : RANGE_LABELS[1]}</span
+                >
+                <span id="label-1"
+                  >${_value[0] < _value[1]!
+                    ? RANGE_LABELS[1]
+                    : RANGE_LABELS[0]}</span
+                >
               </leu-visually-hidden>
             `
           : nothing}
@@ -498,9 +508,9 @@ export class LeuRange extends LeuElement {
               html`<output
                 class="range__output"
                 for="input-${type}"
-                value=${this.formatValue(valueAsArray[index])}
-                style="--value: ${this.getNormalizedValue(valueAsArray[index])}"
-                >${this.formatValue(valueAsArray[index])}</output
+                value=${this.formatValue(_value[index])}
+                style="--value: ${this.getNormalizedValue(_value[index])}"
+                >${this.formatValue(_value[index])}</output
               >`,
           )}
         </div>
@@ -527,12 +537,12 @@ export class LeuRange extends LeuElement {
                 role="slider"
                 aria-valuemin=${this.min}
                 aria-valuemax=${this.max}
-                aria-valuenow=${valueAsArray[index]}
-                aria-valuetext=${this.formatValue(valueAsArray[index])}
+                aria-valuenow=${_value[index]}
+                aria-valuetext=${this.formatValue(_value[index])}
                 step=${this.step}
                 aria-labelledby="label  ${multiple ? `label-${index}` : ""}"
-                ?disabled=${disabled}
-                style="--value: ${this.getNormalizedValue(valueAsArray[index])}"
+                aria-disabled=${disabled}
+                style="--value: ${this.getNormalizedValue(_value[index])}"
                 tabindex=${ifDefined(disabled ? undefined : 0)}
               ></div>
             `,

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -5,6 +5,7 @@ import { ifDefined } from "lit/directives/if-defined.js"
 import styles from "./range.css?inline"
 import { LeuElement } from "../../lib/LeuElement.js"
 import { clamp, isNumber } from "../../lib/utils.js"
+import { LeuVisuallyHidden } from "../visually-hidden/VisuallyHidden.js"
 
 type InternalRangeValue = [number, number] | [number]
 
@@ -29,6 +30,10 @@ export class LeuRange extends LeuElement {
   static shadowRootOptions = {
     ...LeuElement.shadowRootOptions,
     delegatesFocus: true,
+  }
+
+  static dependencies = {
+    "leu-visually-hidden": LeuVisuallyHidden,
   }
 
   /**
@@ -465,7 +470,7 @@ export class LeuRange extends LeuElement {
   render() {
     const inputs = this.multiple ? ["base", "ghost"] : ["base"]
 
-    const { multiple, disabled, label, valueAsArray } = this
+    const { multiple, disabled, label, valueAsArray, hideLabel } = this
     const normalizedRange = this.getNormalizedRange()
 
     return html`
@@ -473,12 +478,20 @@ export class LeuRange extends LeuElement {
         id="container"
         class="range"
         style="--low: ${normalizedRange[0]}; --high: ${normalizedRange[1]}"
-        role=${ifDefined(multiple ? "group" : undefined)}
-        aria-labelledby=${ifDefined(multiple ? "group-label" : undefined)}
       >
+        ${hideLabel
+          ? html`<leu-visually-hidden>
+              <span id="label" class="range__label">${label}</span>
+            </leu-visually-hidden>`
+          : html`<span id="label" class="range__label">${label}</span>`}
         ${multiple
-          ? html`<span id="group-label" class="range__label">${label}</span>`
-          : html`<label for="input-base" class="range__label">${label}</label>`}
+          ? html`
+              <leu-visually-hidden>
+                <span id="label-0">${RANGE_LABELS[0]}</span>
+                <span id="label-1">${RANGE_LABELS[1]}</span>
+              </leu-visually-hidden>
+            `
+          : nothing}
         <div class="range__outputs">
           ${inputs.map(
             (type, index) =>
@@ -486,6 +499,7 @@ export class LeuRange extends LeuElement {
                 class="range__output"
                 for="input-${type}"
                 value=${this.formatValue(valueAsArray[index])}
+                style="--value: ${this.getNormalizedValue(valueAsArray[index])}"
                 >${this.formatValue(valueAsArray[index])}</output
               >`,
           )}
@@ -516,9 +530,7 @@ export class LeuRange extends LeuElement {
                 aria-valuenow=${valueAsArray[index]}
                 aria-valuetext=${this.formatValue(valueAsArray[index])}
                 step=${this.step}
-                aria-label=${ifDefined(
-                  multiple ? RANGE_LABELS[index] : undefined,
-                )}
+                aria-labelledby="label  ${multiple ? `label-${index}` : ""}"
                 ?disabled=${disabled}
                 style="--value: ${this.getNormalizedValue(valueAsArray[index])}"
                 tabindex=${ifDefined(disabled ? undefined : 0)}

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -329,6 +329,11 @@ export class LeuRange extends LeuElement {
      * This is to ensure that the thumb can be fully visible when at the min or max value.
      * This means we have to subtract the radius of the thumb from the width of the track when calculating the normalized value.
      * Pointer events that are outside of the track will be clamped to the min or max value.
+     *
+     * -|<-------------------- track -------------------->|-
+     * (O)-----------------------------------------------(O)
+     *  ^-- first tick                        last tick --^
+     *
      */
     const trimmedWidth = rect.width - THUMB_RADIUS * 2
     const xPosition = clientX - rect.left - THUMB_RADIUS

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -181,22 +181,6 @@ export class LeuRange extends LeuElement {
   @query("#container")
   protected container: HTMLDivElement
 
-  @query("#input-base")
-  protected inputBase: HTMLInputElement
-
-  @query("#input-ghost")
-  protected inputGhost: HTMLInputElement | null
-
-  @query("output[for=input-base]")
-  protected outputBase: HTMLOutputElement
-
-  @query("output[for=input-ghost]")
-  protected outputGhost: HTMLOutputElement | null
-
-  updated() {
-    this.updateStyles()
-  }
-
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     // Reflect defaultValue changes to the value property
     // to ensure backwards compatibility with previous versions
@@ -227,24 +211,6 @@ export class LeuRange extends LeuElement {
     }
   }
 
-  protected updateStyles() {
-    const normalizedRange = this.getNormalizedRange()
-    this.container?.style.setProperty("--low", normalizedRange[0].toString())
-    this.container?.style.setProperty("--high", normalizedRange[1].toString())
-
-    const inputs = this.multiple
-      ? [this.inputBase, this.inputGhost]
-      : [this.inputBase]
-
-    inputs.forEach((input) => {
-      const output =
-        input.id === "input-base" ? this.outputBase : this.outputGhost
-      const normalizedValue = this.getNormalizedValue(input.valueAsNumber)
-      output.style.setProperty("--value", normalizedValue.toString())
-      output.value = this.formatValue(input.valueAsNumber)
-    })
-  }
-
   protected clampAndRoundValue(value: number) {
     const clampedValue = clamp(value, this.min, this.max)
     const roundedValue =
@@ -253,15 +219,7 @@ export class LeuRange extends LeuElement {
     return roundedValue
   }
 
-  protected handleInput(e: Event & { target: HTMLInputElement }) {
-    e.stopPropagation()
-
-    if (this.multiple) {
-      this.value = [this.inputBase.valueAsNumber, this.inputGhost.valueAsNumber]
-    } else {
-      this.value = [this.inputBase.valueAsNumber]
-    }
-
+  protected dispatchInputEvent() {
     this.dispatchEvent(
       new CustomEvent("input", {
         composed: true,
@@ -269,6 +227,45 @@ export class LeuRange extends LeuElement {
         detail: { value: this.value, valueAsArray: this.valueAsArray },
       }),
     )
+  }
+
+  protected async handleKeyDown(e: KeyboardEvent, index: number) {
+    if (this.disabled) return
+
+    const key = e.key
+
+    const currentValue = this._value[index]
+    let nextValue
+
+    if (currentValue === undefined) return
+
+    switch (key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+      case "PageDown":
+        nextValue = currentValue - this.step
+        break
+      case "ArrowRight":
+      case "ArrowUp":
+      case "PageUp":
+        nextValue = currentValue + this.step
+        break
+      case "Home":
+        nextValue = this.min
+        break
+      case "End":
+        nextValue = this.max
+        break
+      default:
+        return
+    }
+
+    const nextValueArray = this._value.slice()
+    nextValueArray[index] = nextValue
+
+    this.value = nextValueArray
+    await this.updateComplete
+    this.dispatchInputEvent()
   }
 
   protected getNormalizedValue(value: number) {
@@ -285,28 +282,6 @@ export class LeuRange extends LeuElement {
     return [0, this.getNormalizedValue(this.valueAsArray[0])]
   }
 
-  /**
-   * This event handler is only applied to the "base" input element and only when in "multiple" mode.
-   * It handles pointer events on the *track* and the thumb.
-   * This method determines if the interaction was closer to the base or the ghost input.
-   */
-  protected handlePointerDown(e: PointerEvent & { target: HTMLInputElement }) {
-    const clickValue =
-      this.min + ((this.max - this.min) * e.offsetX) / this.offsetWidth
-    const middleValue = (this.valueAsArray[0] + this.valueAsArray[1]) / 2
-
-    if (
-      (e.target.valueAsNumber === this.valueLow) ===
-      clickValue > middleValue
-    ) {
-      /**
-       * As the pointerdown event is fired before the input event, we first overwrite the value
-       * of the input element that was not clicked on. The active input element will update itself.
-       */
-      this.inputGhost.value = e.target.value
-    }
-  }
-
   protected formatValue(value: number) {
     if (this.valueFormatter) {
       return this.valueFormatter(value)
@@ -320,14 +295,14 @@ export class LeuRange extends LeuElement {
       return nothing
     }
 
-    return html`<div class="ticks">
+    return html`<div class="range__ticks">
       ${Array.from(
         { length: (this.max - this.min) / this.step + 1 },
         (_, i) => this.min + i * this.step,
       ).map(
         (tick) =>
           html`<span
-            class="tick"
+            class="range__tick"
             style="left: ${this.getNormalizedValue(tick) * 100}%"
           ></span>`,
       )}
@@ -338,59 +313,63 @@ export class LeuRange extends LeuElement {
     const inputs = this.multiple ? ["base", "ghost"] : ["base"]
 
     const { multiple, disabled, label, valueAsArray } = this
+    const normalizedRange = this.getNormalizedRange()
 
     return html`
       <div
         id="container"
-        class="container"
+        class="range"
+        style="--low: ${normalizedRange[0]}; --high: ${normalizedRange[1]}"
         role=${ifDefined(multiple ? "group" : undefined)}
         aria-labelledby=${ifDefined(multiple ? "group-label" : undefined)}
       >
         ${multiple
-          ? html`<span id="group-label" class="label">${label}</span>`
-          : html`<label for="input-base" class="label">${label}</label>`}
-        <div class="outputs">
+          ? html`<span id="group-label" class="range__label">${label}</span>`
+          : html`<label for="input-base" class="range__label">${label}</label>`}
+        <div class="range__outputs">
           ${inputs.map(
             (type, index) =>
               html`<output
-                class="output"
+                class="range__output"
                 for="input-${type}"
                 value=${this.formatValue(valueAsArray[index])}
-              ></output>`,
+                >${this.formatValue(valueAsArray[index])}</output
+              >`,
           )}
         </div>
-        <div class="inputs">
+        <div class="range__track">
           ${inputs.map(
             (type, index) => html`
-              <input
-                @input=${this.handleInput}
-                @pointerdown=${multiple && !disabled && index === 0
-                  ? this.handlePointerDown
-                  : undefined}
+              <div
+                @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e, index)}
                 type="range"
-                class="range range--${type}"
+                class="range__thumb range__thumb--${type}"
                 id="input-${type}"
                 name=${this.name}
-                min=${this.min}
-                max=${this.max}
+                role="slider"
+                aria-valuemin=${this.min}
+                aria-valuemax=${this.max}
+                aria-valuenow=${valueAsArray[index]}
+                aria-valuetext=${this.formatValue(valueAsArray[index])}
                 step=${this.step}
                 aria-label=${ifDefined(
                   multiple ? RANGE_LABELS[index] : undefined,
                 )}
                 ?disabled=${disabled}
-                .value=${valueAsArray[index].toString()}
-              />
+                style="--value: ${this.getNormalizedValue(valueAsArray[index])}"
+                tabindex=${ifDefined(disabled ? undefined : 0)}
+              ></div>
             `,
           )}
           ${this.renderTicks()}
         </div>
       </div>
       ${this.showRangeLabels
-        ? html`<div class="tick-labels">
-            <span class="tick-label tick-label--min"
+        ? html`<div class="range__tick-labels">
+            <span class="range__tick-label range__tick-label--min"
               >${this.formatValue(this.min)}</span
             >
-            <span class="tick-label tick-label--max"
+            <span class="range__tick-label range__tick-label--max"
               >${this.formatValue(this.max)}</span
             >
           </div>`

--- a/src/components/range/Range.ts
+++ b/src/components/range/Range.ts
@@ -18,6 +18,7 @@ const defaultValueConverter = {
 }
 
 const RANGE_LABELS = ["Von", "Bis"]
+const THUMB_RADIUS = 16
 
 /**
  * @tagname leu-range
@@ -179,7 +180,29 @@ export class LeuRange extends LeuElement {
   }
 
   @query("#container")
-  protected container: HTMLDivElement
+  protected container!: HTMLDivElement
+
+  @query("#track")
+  protected track!: HTMLDivElement
+
+  protected activePointerId: number | null = null
+
+  protected activeThumbIndex: number | null = null
+
+  protected resizeObserver = new ResizeObserver(() => {
+    this.trackRect = this.track.getBoundingClientRect()
+  })
+
+  protected trackRect: DOMRect | null = null
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback()
+    this.resizeObserver.disconnect()
+  }
+
+  protected firstUpdated(): void {
+    this.resizeObserver.observe(this.track)
+  }
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     // Reflect defaultValue changes to the value property
@@ -277,6 +300,127 @@ export class LeuRange extends LeuElement {
     return (value - this.min) / (this.max - this.min)
   }
 
+  protected getValueFromClientX(clientX: number) {
+    const rect = this.trackRect ?? this.track.getBoundingClientRect()
+
+    /**
+     * If the track has no width, we cannot calculate a normalized value (dividing by zero).
+     */
+    if (rect.width === 0) {
+      return this.valueAsArray[0]
+    }
+
+    /**
+     * The first and the list tick of the range slider
+     * are not at the very edge of the track, but are offset by the radius of the thumb.
+     * This is to ensure that the thumb can be fully visible when at the min or max value.
+     * This means we have to subtract the radius of the thumb from the width of the track when calculating the normalized value.
+     * Pointer events that are outside of the track will be clamped to the min or max value.
+     */
+    const trimmedWidth = rect.width - THUMB_RADIUS * 2
+    const xPosition = clientX - rect.left - THUMB_RADIUS
+
+    const normalizedValue = clamp(xPosition / trimmedWidth, 0, 1)
+
+    const rawValue = normalizedValue * (this.max - this.min) + this.min
+
+    return this.clampAndRoundValue(rawValue)
+  }
+
+  protected getClosestThumbIndex(nextValue: number) {
+    if (
+      !this.multiple ||
+      this._value.length < 2 ||
+      typeof this._value[1] === "undefined"
+    )
+      return 0
+
+    const distanceToFirst = Math.abs(this._value[0] - nextValue)
+    const distanceToSecond = Math.abs(this._value[1] - nextValue)
+
+    return distanceToFirst <= distanceToSecond ? 0 : 1
+  }
+
+  protected updateThumbValue(index: number, nextValue: number) {
+    if (this._value[index] === undefined || this._value[index] === nextValue) {
+      return
+    }
+
+    const nextValueArray = this.valueAsArray
+    nextValueArray[index] = nextValue
+
+    this.value = nextValueArray
+    this.dispatchInputEvent()
+  }
+
+  protected handleThumbPointerDown(e: PointerEvent, index: number) {
+    if (this.disabled) {
+      return
+    }
+
+    this.activeThumbIndex = index
+  }
+
+  protected handlePointerDown(e: PointerEvent) {
+    if (this.disabled) {
+      return
+    }
+
+    e.preventDefault()
+
+    const track = e.currentTarget as HTMLDivElement
+    const nextValue = this.getValueFromClientX(e.clientX)
+
+    this.activePointerId = e.pointerId
+    this.activeThumbIndex ??= this.getClosestThumbIndex(nextValue)
+
+    track.setPointerCapture(e.pointerId)
+    this.updateThumbValue(this.activeThumbIndex, nextValue)
+
+    const thumb = this.renderRoot.querySelector<HTMLElement>(
+      `.range__thumb[data-thumb-index="${this.activeThumbIndex}"]`,
+    )
+    thumb?.focus()
+  }
+
+  protected handlePointerMove(e: PointerEvent) {
+    if (
+      this.disabled ||
+      this.activePointerId !== e.pointerId ||
+      this.activeThumbIndex === null
+    ) {
+      return
+    }
+
+    e.preventDefault()
+
+    const nextValue = this.getValueFromClientX(e.clientX)
+    this.updateThumbValue(this.activeThumbIndex, nextValue)
+  }
+
+  protected resetActivePointerState() {
+    this.activePointerId = null
+    this.activeThumbIndex = null
+  }
+
+  protected handlePointerEnd(e: PointerEvent) {
+    if (this.activePointerId !== e.pointerId) {
+      return
+    }
+
+    const track = e.currentTarget as HTMLDivElement
+
+    if (track.hasPointerCapture(e.pointerId)) {
+      track.releasePointerCapture(e.pointerId)
+    }
+
+    this.resetActivePointerState()
+  }
+
+  protected handleLostPointerCapture() {
+    this.resetActivePointerState()
+  }
+
   protected getNormalizedRange() {
     if (this.multiple) {
       return this.valueAsArray
@@ -342,13 +486,24 @@ export class LeuRange extends LeuElement {
               >`,
           )}
         </div>
-        <div class="range__track">
+        <div
+          id="track"
+          class="range__track"
+          @pointerdown=${this.handlePointerDown}
+          @pointermove=${this.handlePointerMove}
+          @pointerup=${this.handlePointerEnd}
+          @pointercancel=${this.handlePointerEnd}
+          @lostpointercapture=${this.handleLostPointerCapture}
+        >
           ${inputs.map(
             (type, index) => html`
               <div
                 @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e, index)}
+                @pointerdown=${(e: PointerEvent) =>
+                  this.handleThumbPointerDown(e, index)}
                 type="range"
                 class="range__thumb range__thumb--${type}"
+                data-thumb-index=${index}
                 id="input-${type}"
                 name=${this.name}
                 role="slider"

--- a/src/components/range/range.css
+++ b/src/components/range/range.css
@@ -14,6 +14,8 @@
   --range-thumb-color: var(--leu-color-black-0);
   --range-thumb-border-color: var(--range-color);
   --range-thumb-hover-border-color: var(--leu-color-black-100);
+
+  /* This value is hard-coded in the component file. If you change it here, make sure to update it there as well. */
   --range-thumb-diameter: 32px;
 
   --range-value-color: var(--leu-color-black-100);
@@ -90,6 +92,7 @@
 .range__track {
   position: relative;
   height: var(--range-thumb-diameter);
+  touch-action: none;
 
   --_track-background: linear-gradient(
     to right,
@@ -129,6 +132,7 @@
   border-radius: 50%;
 
   pointer-events: all;
+  touch-action: none;
 }
 
 .range__thumb:focus {

--- a/src/components/range/range.css
+++ b/src/components/range/range.css
@@ -35,19 +35,19 @@
   --range-value-color: var(--range-value-color-disabled);
 }
 
-.container {
+.range {
   position: relative;
 }
 
-.label {
+.range__label {
   display: inline-block;
   margin-block-end: 0.5rem;
   color: var(--leu-color-black-100);
   font: var(--leu-t-regular-regular-font);
 }
 
-:host([hide-label]) .label {
-  clip: rect(0 0 0 0);
+:host([hide-label]) .range__label {
+  /* clip: rect(0 0 0 0); FIXME */
   border: 0;
   height: 1px;
   margin: -1px !important;
@@ -57,13 +57,13 @@
   width: 1px;
 }
 
-.outputs {
+.range__outputs {
   position: relative;
   height: 1.5rem;
   margin-block-end: 0.25rem;
 }
 
-.output {
+.range__output {
   position: absolute;
 
   text-align: center;
@@ -79,19 +79,17 @@
   transform: translateX(calc(-50% + var(--range-thumb-diameter) / 2));
 }
 
-.inputs {
-  position: relative;
-  z-index: 1;
-  height: var(--range-thumb-diameter);
+.range__output:nth-child(1) {
+  --value: var(--high);
 }
 
-.range {
-  appearance: none;
-  width: 100%;
+.range__output:nth-child(2) {
+  --value: var(--low);
+}
+
+.range__track {
+  position: relative;
   height: var(--range-thumb-diameter);
-  padding: 0;
-  margin: 0;
-  background: transparent;
 
   --_track-background: linear-gradient(
     to right,
@@ -102,101 +100,58 @@
   );
 }
 
-.range--ghost {
+.range__track::after {
+  content: "";
   position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.range:focus {
-  outline: none;
+  z-index: 0;
+  width: 100%;
+  top: 50%;
+  background: var(--_track-background);
+  border-radius: var(--range-track-radius);
+  height: var(--range-track-height);
+  transform: translateY(-50%);
 }
 
 /* Thumb */
 
-.range::-moz-range-thumb {
+.range__thumb {
+  position: absolute;
+  z-index: 1;
+  left: calc(var(--value) * (100% - var(--range-thumb-diameter)));
+
+  height: var(--range-thumb-diameter);
+  width: var(--range-thumb-diameter);
+
   cursor: pointer;
   background: var(--range-thumb-color);
 
   border: 2px var(--range-thumb-border-color) solid;
   border-radius: 50%;
 
-  height: var(--range-thumb-diameter);
-  width: var(--range-thumb-diameter);
-
   pointer-events: all;
 }
 
-.range:disabled::-moz-range-thumb {
-  cursor: not-allowed;
+.range__thumb:focus {
+  outline: none;
 }
 
-.range:focus-visible::-moz-range-thumb {
+.range__thumb:focus-visible {
   outline: 2px solid var(--range-color-focus);
   outline-offset: 2px;
 }
 
-.range::-moz-range-thumb:hover,
-.range:focus-visible::-moz-range-thumb {
+.range__thumb:hover,
+.range__thumb:focus-visible {
   border-color: var(--range-thumb-hover-border-color);
 }
 
-.range::-webkit-slider-thumb {
-  appearance: none;
-  cursor: pointer;
-  background: var(--range-thumb-color);
-
-  border: 2px var(--range-thumb-border-color) solid;
-  border-radius: 50%;
-
-  height: var(--range-thumb-diameter);
-  width: var(--range-thumb-diameter);
-  margin-top: calc(var(--range-thumb-diameter) / -2 + 2px);
-
-  pointer-events: all;
-}
-
-.range:disabled::-webkit-slider-thumb {
+:host(:disabled) .range__thumb {
   cursor: not-allowed;
-}
-
-.range:focus::-webkit-slider-thumb {
-  outline: 2px solid var(--range-color-focus);
-  outline-offset: 2px;
-}
-
-.range:focus::-webkit-slider-thumb,
-.range::-webkit-slider-thumb:hover {
-  border-color: var(--range-thumb-hover-border-color);
-}
-
-/* Track */
-
-.range::-moz-range-track {
-  background: var(--_track-background);
-  border-radius: var(--range-track-radius);
-  height: var(--range-track-height);
-}
-
-.range--ghost::-moz-range-track {
-  background: transparent;
-}
-
-.range::-webkit-slider-runnable-track {
-  background: var(--_track-background);
-  border-radius: var(--range-track-radius);
-  height: var(--range-track-height);
-}
-
-.range--ghost::-webkit-slider-runnable-track {
-  background: transparent;
 }
 
 /* Ticks */
 
-.ticks {
+.range__ticks {
   position: absolute;
   inset-block-start: calc(
     var(--range-thumb-diameter) / 2 + var(--range-track-height)
@@ -204,7 +159,7 @@
   inset-inline: calc(var(--range-thumb-diameter) / 2);
 }
 
-.tick {
+.range__tick {
   z-index: -1;
   position: absolute;
   top: 50%;
@@ -214,7 +169,7 @@
   transform: translateY(-50%);
 }
 
-.tick-labels {
+.range__tick-labels {
   display: flex;
   justify-content: space-between;
   color: var(--leu-color-black-60);
@@ -222,6 +177,6 @@
   margin-top: 0.25rem;
 }
 
-.tick-label--max {
+.range__tick-label--max {
   text-align: right;
 }

--- a/src/components/range/range.css
+++ b/src/components/range/range.css
@@ -48,17 +48,6 @@
   font: var(--leu-t-regular-regular-font);
 }
 
-:host([hide-label]) .range__label {
-  /* clip: rect(0 0 0 0); FIXME */
-  border: 0;
-  height: 1px;
-  margin: -1px !important;
-  overflow: hidden;
-  padding: 0 !important;
-  position: absolute;
-  width: 1px;
-}
-
 .range__outputs {
   position: relative;
   height: 1.5rem;
@@ -79,14 +68,6 @@
 
   left: calc(var(--value) * (var(--_stop) - var(--_start)) + var(--_start));
   transform: translateX(calc(-50% + var(--range-thumb-diameter) / 2));
-}
-
-.range__output:nth-child(1) {
-  --value: var(--high);
-}
-
-.range__output:nth-child(2) {
-  --value: var(--low);
 }
 
 .range__track {

--- a/src/components/range/stories/range.stories.ts
+++ b/src/components/range/stories/range.stories.ts
@@ -78,7 +78,13 @@ export const Disabled = {
 
 export const Step = {
   ...Template,
-  args: { min: 5, max: 123, step: 13 },
+  args: {
+    min: 5,
+    max: 134,
+    step: 13,
+    "show-ticks": true,
+    "show-range-labels": true,
+  },
 }
 
 export const Ticks = {
@@ -119,11 +125,24 @@ export const CustomFormatter = {
 
 function CombinedTemplate(args: StoryArgs) {
   const values = (args.value ?? "").split(",").map((v) => Number(v.trim()))
-  function handleInputInput() {
+  const valueState = [...values]
+
+  function updateAndSyncState(newValues: number[]) {
+    valueState[0] = newValues[0]
+    valueState[1] = newValues[1]
     const inputs = document.querySelectorAll("leu-input")
     const range = document.querySelector("leu-range")
-    range.value = [inputs[0].value, inputs[1].value]
+
+    inputs[0].value = valueState[0].toString()
+    inputs[1].value = valueState[1].toString()
+    range.value = valueState
   }
+
+  function handleInputInput() {
+    const inputs = document.querySelectorAll("leu-input")
+    updateAndSyncState([inputs[0].value, inputs[1].value].map((v) => Number(v)))
+  }
+
   return html`
     <leu-range
       label=${args.label}
@@ -139,11 +158,7 @@ function CombinedTemplate(args: StoryArgs) {
       ?show-ticks=${args["show-ticks"]}
       ?show-range-labels=${args["show-range-labels"]}
       @input=${(e) => {
-        const inputs = document.querySelectorAll("leu-input")
-        const valueList = e.target.valueAsArray
-
-        inputs[0].value = valueList[0]
-        inputs[1].value = valueList[1]
+        updateAndSyncState(e.target.valueAsArray)
       }}
     >
     </leu-range>

--- a/src/components/range/test/range.test.ts
+++ b/src/components/range/test/range.test.ts
@@ -1,9 +1,54 @@
 import { html } from "lit"
 import { fixture, expect } from "@open-wc/testing"
+import { resetMouse, sendKeys, sendMouse } from "@web/test-runner-commands"
 import { ifDefined } from "lit/directives/if-defined.js"
 
 import "../leu-range.js"
 import type { LeuRange } from "../leu-range.js"
+
+function getPointInElement(
+  element: Element,
+  xFraction: number,
+  yFraction = 0.5,
+) {
+  const { left, top, width, height } = element.getBoundingClientRect()
+  const safeXFraction = Math.min(Math.max(xFraction, 0), 0.999)
+
+  return {
+    x: Math.floor(left + window.pageXOffset + width * safeXFraction),
+    y: Math.floor(top + window.pageYOffset + height * yFraction),
+  }
+}
+
+async function moveMouseToElementPoint(
+  element: Element,
+  xFraction: number,
+  yFraction = 0.5,
+) {
+  const { x, y } = getPointInElement(element, xFraction, yFraction)
+  await sendMouse({ type: "move", position: [x, y] })
+}
+
+const THUMB_RADIUS = 16
+
+function getPointInTrack(element: Element, xFraction: number) {
+  const { left, top, width, height } = element.getBoundingClientRect()
+  const safeXFraction = Math.min(Math.max(xFraction, 0), 0.999)
+  const yFraction = 0.5
+
+  const trackWidth = width - THUMB_RADIUS * 2
+  const trackLeft = left + THUMB_RADIUS
+
+  const x = Math.floor(trackLeft + trackWidth * safeXFraction)
+  const y = Math.floor(top + window.pageYOffset + height * yFraction)
+
+  return { x, y }
+}
+
+async function moveMouseToTrackPoint(element: Element, xFraction: number) {
+  const { x, y } = getPointInTrack(element, xFraction)
+  await sendMouse({ type: "move", position: [x, y] })
+}
 
 async function defaultFixture(args = {}) {
   return fixture<LeuRange>(html`
@@ -27,6 +72,10 @@ async function defaultFixture(args = {}) {
 }
 
 describe("LeuRange", () => {
+  afterEach(async () => {
+    await resetMouse()
+  })
+
   it("is a defined element", async () => {
     const el = customElements.get("leu-range")
 
@@ -224,5 +273,127 @@ describe("LeuRange", () => {
     await el.updateComplete
 
     expect(el.value).to.equal("4,6")
+  })
+
+  it("updates value and emits input on pointer down", async () => {
+    const el = await defaultFixture({ min: 0, max: 100, value: 50 })
+
+    const track = el.shadowRoot!.querySelector<HTMLDivElement>("#track")!
+
+    const events: string[] = []
+    el.addEventListener("input", () => {
+      events.push(el.value)
+    })
+
+    await moveMouseToTrackPoint(track, 1)
+    await sendMouse({ type: "down" })
+    await sendMouse({ type: "up" })
+
+    await el.updateComplete
+
+    expect(el.value).to.equal("100")
+    expect(events).to.deep.equal(["100"])
+  })
+
+  it("updates while dragging and stops after pointer up", async () => {
+    const el = await defaultFixture({ min: 0, max: 100, value: 50 })
+
+    const track = el.shadowRoot!.querySelector<HTMLDivElement>("#track")!
+
+    await moveMouseToTrackPoint(track, 0)
+    await sendMouse({ type: "down" })
+    await el.updateComplete
+    expect(el.value).to.equal("0")
+
+    await moveMouseToTrackPoint(track, 1)
+    await el.updateComplete
+    expect(el.value).to.equal("100")
+
+    await sendMouse({ type: "up" })
+
+    await moveMouseToTrackPoint(track, 0)
+    await el.updateComplete
+    expect(el.value).to.equal("100")
+  })
+
+  it("moves the closest thumb on track pointer down in multiple mode", async () => {
+    const el = await defaultFixture({
+      multiple: true,
+      min: 0,
+      max: 100,
+      value: "20,80",
+    })
+
+    const track = el.shadowRoot!.querySelector<HTMLDivElement>("#track")!
+
+    await moveMouseToTrackPoint(track, 0.65)
+    await sendMouse({ type: "down" })
+    await sendMouse({ type: "up" })
+
+    await el.updateComplete
+
+    const [low, high] = el.value.split(",").map((v) => Number(v))
+    expect(low).to.equal(20)
+    expect(high).to.equal(65)
+  })
+
+  it("keeps the thumb selected from thumb pointer down while dragging", async () => {
+    const el = await defaultFixture({
+      multiple: true,
+      min: 0,
+      max: 100,
+      value: "20,80",
+    })
+
+    const track = el.shadowRoot!.querySelector<HTMLDivElement>("#track")!
+    const highThumb = el.shadowRoot!.querySelector<HTMLDivElement>(
+      '.range__thumb[data-thumb-index="1"]',
+    )!
+
+    await moveMouseToElementPoint(highThumb, 0.5)
+    await sendMouse({ type: "down" })
+    await moveMouseToTrackPoint(track, 0)
+    await sendMouse({ type: "up" })
+
+    await el.updateComplete
+    expect(el.value).to.equal("20,0")
+  })
+
+  it("updates the focused thumb with keyboard shortcuts", async () => {
+    const el = await defaultFixture({ min: 0, max: 10, step: 2, value: 4 })
+
+    await sendKeys({ press: "Tab" })
+
+    await sendKeys({ press: "ArrowRight" })
+    await el.updateComplete
+    expect(el.value).to.equal("6")
+
+    await sendKeys({ press: "PageUp" })
+    await el.updateComplete
+    expect(el.value).to.equal("10")
+
+    await sendKeys({ press: "Home" })
+    await el.updateComplete
+    expect(el.value).to.equal("0")
+  })
+
+  it("moves only the focused thumb in multiple mode", async () => {
+    const el = await defaultFixture({
+      multiple: true,
+      min: 0,
+      max: 100,
+      step: 10,
+      value: "20,80",
+    })
+
+    await sendKeys({ press: "Tab" })
+    await sendKeys({ press: "ArrowRight" })
+    await el.updateComplete
+    expect(el.value).to.equal("30,80")
+
+    await sendKeys({ press: "Tab" })
+    await sendKeys({ press: "ArrowLeft" })
+    await el.updateComplete
+    expect(el.value).to.equal("30,70")
   })
 })

--- a/src/components/range/test/range.test.ts
+++ b/src/components/range/test/range.test.ts
@@ -225,4 +225,67 @@ describe("LeuRange", () => {
 
     expect(el.value).to.equal("4,6")
   })
+
+  it("updates value from pointer events on the track", async () => {
+    const el = await defaultFixture({ min: 0, max: 100, value: 20 })
+
+    const track = el.shadowRoot?.querySelector(
+      ".range__track",
+    ) as HTMLDivElement
+    expect(track).to.exist
+
+    track.getBoundingClientRect = () => ({ left: 0, width: 200 }) as DOMRect
+
+    track.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        composed: true,
+        pointerId: 1,
+        clientX: 100,
+      }),
+    )
+    await el.updateComplete
+
+    expect(el.value).to.equal("50")
+  })
+
+  it("moves the closest thumb for track pointer events in multiple mode", async () => {
+    const el = await defaultFixture({
+      multiple: true,
+      min: 0,
+      max: 100,
+      value: "20,80",
+    })
+
+    const track = el.shadowRoot?.querySelector(
+      ".range__track",
+    ) as HTMLDivElement
+    expect(track).to.exist
+
+    track.getBoundingClientRect = () => ({ left: 0, width: 100 }) as DOMRect
+
+    track.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        composed: true,
+        pointerId: 2,
+        clientX: 75,
+      }),
+    )
+    await el.updateComplete
+
+    expect(el.value).to.equal("20,75")
+
+    track.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        composed: true,
+        pointerId: 3,
+        clientX: 10,
+      }),
+    )
+    await el.updateComplete
+
+    expect(el.value).to.equal("10,75")
+  })
 })

--- a/src/components/range/test/range.test.ts
+++ b/src/components/range/test/range.test.ts
@@ -47,7 +47,7 @@ describe("LeuRange", () => {
   it("renders the label", async () => {
     const el = await defaultFixture({ label: "Test Label" })
 
-    const label = el.shadowRoot?.querySelector(".label")
+    const label = el.shadowRoot?.querySelector(".range__label")
 
     expect(label).to.exist
     expect(label).to.contain.text("Test Label")
@@ -56,7 +56,7 @@ describe("LeuRange", () => {
   it("renders the label visually hidden when 'hide-label' is set", async () => {
     const el = await defaultFixture({ label: "Test Label", "hide-label": true })
 
-    const label = el.shadowRoot?.querySelector(".label")
+    const label = el.shadowRoot?.querySelector(".range__label")
 
     expect(label).to.exist
     expect(label).to.contain.text("Test Label")
@@ -70,8 +70,8 @@ describe("LeuRange", () => {
       "show-range-labels": true,
     })
 
-    const minLabel = el.shadowRoot?.querySelector(".tick-label--min")
-    const maxLabel = el.shadowRoot?.querySelector(".tick-label--max")
+    const minLabel = el.shadowRoot?.querySelector(".range__tick-label--min")
+    const maxLabel = el.shadowRoot?.querySelector(".range__tick-label--max")
 
     expect(minLabel).to.exist
     expect(maxLabel).to.exist
@@ -88,10 +88,10 @@ describe("LeuRange", () => {
       "show-ticks": true,
     })
 
-    const ticksContainer = el.shadowRoot?.querySelector(".ticks")
+    const ticksContainer = el.shadowRoot?.querySelector(".range__ticks")
     expect(ticksContainer).to.exist
 
-    const ticks = ticksContainer?.querySelectorAll(".tick")
+    const ticks = ticksContainer?.querySelectorAll(".range__tick")
     expect(ticks?.length).to.equal(4)
   })
 
@@ -105,8 +105,8 @@ describe("LeuRange", () => {
       "show-range-labels": true,
     })
 
-    const minLabel = el.shadowRoot?.querySelector(".tick-label--min")
-    const maxLabel = el.shadowRoot?.querySelector(".tick-label--max")
+    const minLabel = el.shadowRoot?.querySelector(".range__tick-label--min")
+    const maxLabel = el.shadowRoot?.querySelector(".range__tick-label--max")
     const valueLabel = el.shadowRoot?.querySelector("output")
 
     expect(minLabel).to.exist
@@ -127,8 +127,8 @@ describe("LeuRange", () => {
       "show-range-labels": true,
     })
 
-    const minLabel = el.shadowRoot?.querySelector(".tick-label--min")
-    const maxLabel = el.shadowRoot?.querySelector(".tick-label--max")
+    const minLabel = el.shadowRoot?.querySelector(".range__tick-label--min")
+    const maxLabel = el.shadowRoot?.querySelector(".range__tick-label--max")
     const valueLabel = el.shadowRoot?.querySelector("output")
 
     expect(minLabel).to.exist
@@ -151,8 +151,8 @@ describe("LeuRange", () => {
       "show-range-labels": true,
     })
 
-    const minLabel = el.shadowRoot?.querySelector(".tick-label--min")
-    const maxLabel = el.shadowRoot?.querySelector(".tick-label--max")
+    const minLabel = el.shadowRoot?.querySelector(".range__tick-label--min")
+    const maxLabel = el.shadowRoot?.querySelector(".range__tick-label--max")
     const valueLabel = el.shadowRoot?.querySelector("output")
 
     expect(minLabel).to.contain.text("10/11")
@@ -163,8 +163,8 @@ describe("LeuRange", () => {
   it("disables the range slider", async () => {
     const el = await defaultFixture({ disabled: true })
 
-    const input = el.shadowRoot?.querySelector("input")
-    expect(input).to.have.attribute("disabled")
+    const input = el.shadowRoot?.querySelector("[role=slider]")
+    expect(input).to.have.attribute("aria-disabled", "true")
   })
 
   it("clamps and rounds when value is set", async () => {
@@ -224,68 +224,5 @@ describe("LeuRange", () => {
     await el.updateComplete
 
     expect(el.value).to.equal("4,6")
-  })
-
-  it("updates value from pointer events on the track", async () => {
-    const el = await defaultFixture({ min: 0, max: 100, value: 20 })
-
-    const track = el.shadowRoot?.querySelector(
-      ".range__track",
-    ) as HTMLDivElement
-    expect(track).to.exist
-
-    track.getBoundingClientRect = () => ({ left: 0, width: 200 }) as DOMRect
-
-    track.dispatchEvent(
-      new PointerEvent("pointerdown", {
-        bubbles: true,
-        composed: true,
-        pointerId: 1,
-        clientX: 100,
-      }),
-    )
-    await el.updateComplete
-
-    expect(el.value).to.equal("50")
-  })
-
-  it("moves the closest thumb for track pointer events in multiple mode", async () => {
-    const el = await defaultFixture({
-      multiple: true,
-      min: 0,
-      max: 100,
-      value: "20,80",
-    })
-
-    const track = el.shadowRoot?.querySelector(
-      ".range__track",
-    ) as HTMLDivElement
-    expect(track).to.exist
-
-    track.getBoundingClientRect = () => ({ left: 0, width: 100 }) as DOMRect
-
-    track.dispatchEvent(
-      new PointerEvent("pointerdown", {
-        bubbles: true,
-        composed: true,
-        pointerId: 2,
-        clientX: 75,
-      }),
-    )
-    await el.updateComplete
-
-    expect(el.value).to.equal("20,75")
-
-    track.dispatchEvent(
-      new PointerEvent("pointerdown", {
-        bubbles: true,
-        composed: true,
-        pointerId: 3,
-        clientX: 10,
-      }),
-    )
-    await el.updateComplete
-
-    expect(el.value).to.equal("10,75")
   })
 })


### PR DESCRIPTION
Refactor range component so that it uses one or two (multiple=true) custom sliders instead of native input range elements.

Using multiple input range elements was a hacky solution for a single multi-thumb slider.

This change fixes multiple fired input events when syncing the application state with the component state.